### PR TITLE
Fixes issue that caused key "id" to be saved as an authority

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -245,6 +245,16 @@ class Api {
         });
     };
 
+    // Calling role.save() would result in an error in d2 because d2 expects you always want to
+    // save { id: <ID> } objects but authorities should be saved as a plain JSON array
+    saveRole(data) {
+        if (data.id) {
+            return this.d2Api.update(`/userRoles/${data.id}`, data);
+        } else {
+            return this.d2Api.post('/userRoles/', data);
+        }
+    }
+
     /**************************
      ****** CURRENT USER ******
      **************************/

--- a/src/containers/RoleForm/RoleForm.js
+++ b/src/containers/RoleForm/RoleForm.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import { Field, reduxForm } from 'redux-form';
 import RaisedButton from 'material-ui/RaisedButton';
+import api from '../../api';
 import navigateTo from '../../utils/navigateTo';
 import asyncValidateUniqueness from '../../utils/asyncValidateUniqueness';
 import { clearItem, showSnackbar, getList } from '../../actions';
@@ -20,12 +21,15 @@ import validate from './validate';
 class RoleForm extends Component {
     saveRole = async (values, _, props) => {
         const { role, showSnackbar, clearItem, getList } = props;
-        role[NAME] = values[NAME];
-        role[DESCRIPTION] = values[DESCRIPTION];
-        role[AUTHORITIES] = values[AUTHORITIES].map(value => ({ id: value }));
+        const data = {
+            ...role.toJSON(),
+            [NAME]: values[NAME],
+            [DESCRIPTION]: values[DESCRIPTION],
+            [AUTHORITIES]: values[AUTHORITIES],
+        };
 
         try {
-            await role.save();
+            await api.saveRole(data);
             const msg = i18n.t('User role "{{displayName}}" saved successfully', {
                 displayName: role.displayName,
             });


### PR DESCRIPTION
- Roles were being saved by simply calling `role.save` (role being an instance of a d2 role model).
- This method expects that all arrays are populated by objects with this structure { id, <ID> }. If the authorities array would be a plain list of strings, d2 will send an empty array to the server.
- But if the authorities payload has this structure, the server will save the key "id" as an authority too. the server does expect a plain list of strings.
- So as a result of this discrepancy, saving now happens by calling post/update on the d2 API instance.