### PR TITLE
Use webpack.BannerPlugin to inject copyright comment at top of production bundle

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -35,6 +35,15 @@ const globals = Object.assign(
     env.stringified
 );
 
+const appLicense = `/* DHIS2 User App
+ *
+ * Copyright (c) 2018-present, DHIS2.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/dhis2/user-app/blob/master/LICENSE
+ */`;
+
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
 if (env.stringified['process.env'].NODE_ENV !== '"production"') {
@@ -355,6 +364,11 @@ module.exports = {
         // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
         // You can remove this if you don't use Moment.js:
         new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+        new webpack.BannerPlugin({
+            banner: appLicense,
+            raw: true,
+            entryOnly: true,
+        }),
     ],
     // Some libraries import Node modules but don't use them in the browser.
     // Tell Webpack to provide empty mocks for them so importing them works.

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
   },
   "devDependencies": {
     "babel-polyfill": "^6.26.0",
+    "banner-webpack-plugin": "^0.2.3",
     "d2-manifest": "^1.0.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,6 +1182,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+banner-webpack-plugin@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/banner-webpack-plugin/-/banner-webpack-plugin-0.2.3.tgz#e9dee9d9644ccef1fd970e11d82408aff42290eb"
+
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"


### PR DESCRIPTION
The built production bundle now looks like this:
```javascript
/* DHIS2 User App
 *
 * Copyright (c) 2018-present, DHIS2.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 * https://github.com/dhis2/user-app/blob/master/LICENSE
 */
!function(e){function t(r){if(n[r])return n[r].exports;var o=n[r]={i:r,l:!1,exports:{}};return e[r].call
// etc etc
```