### PR TITLE
Fix repeated GET requests after saving user that is also the current user

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -301,12 +301,12 @@ class Api {
             'userCredentials[:all,!user,userRoles[id]',
         ];
         const models = this.d2.models;
-        const userSettings = this.d2.currentUser.userSettings;
 
         return Promise.all([
             this.d2Api.get('me', { fields: meFields }),
             this.d2Api.get('me/authorization'),
-        ]).then(([me, authorities]) => {
+            this.d2Api.get('userSettings'),
+        ]).then(([me, authorities, userSettings]) => {
             this.d2.currentUser = CurrentUserClass.create(
                 me,
                 authorities,


### PR DESCRIPTION
A problem I struggled with in the user-app, is the fact that it is also possible to change the current user, and its related user-groups and roles. This means the `d2.currentUser` model should be updated under certain circumstances and d2 doesn't simply offer a `d2.currentUser.reload()` method. So, I introduced some logic which creates a new currentUser instance and replaces the currentUser of my d2 instance with that.

However, there turned out to be two things wrong with my approach:
1. I was passing the wrong `userSettings` object to `CurrentUserClass.create`. I should have passed  `this.d2.currentUser.userSettings.settings` but I was passing `this.d2.currentUser.userSettings`. You can see why this was triggering lots of get requests [in this section of d2](https://github.com/dhis2/d2/blob/master/src/current-user/UserSettings.js#L53-L55): because `this.settings[key]` was undefined it kept doing these GET requests. So passing the correct object as the `userSettings` parameter fixed redundant GET requests.
2. I then also realised that this `userSettings` object should be retrieved fresh from the server, because some of its properties (`keyUiLocale` and `keyUiLocale`) could have changed too when updating the current user via the user-app

So..... Quite a complicated bug but a PR with only 2 additions and 2 deletions. LOL