### PR TITLE
Dhis2 5511 unable to create user group

### DIFF
--- a/src/containers/GroupForm/GroupForm.js
+++ b/src/containers/GroupForm/GroupForm.js
@@ -8,7 +8,6 @@ import CircularProgress from 'material-ui/CircularProgress';
 import makeTrashable from 'trashable';
 import navigateTo from '../../utils/navigateTo';
 import { asyncValidatorSwitch } from '../../utils/validatorsAsync';
-import asArray from '../../utils/asArray';
 import { renderSearchableGroupEditor } from '../../utils/fieldRenderers';
 import createHumanErrorMessage from '../../utils/createHumanErrorMessage';
 import { clearItem, showSnackbar, getList } from '../../actions';
@@ -77,8 +76,8 @@ class GroupForm extends Component {
 
         group[NAME] = values[NAME];
         group[CODE] = values[CODE];
-        group[USERS] = (values[USERS] || []).map(this.createIdValueObject);
-        group[MANAGED_GROUPS] = (values[MANAGED_GROUPS] || []).map(this.createIdValueObject);
+        group[USERS] = values[USERS].map(this.createIdValueObject);
+        group[MANAGED_GROUPS] = values[MANAGED_GROUPS].map(this.createIdValueObject);
         group.attributeValues = parseAttributeValues(values, this.state.attributeFields);
 
         try {
@@ -208,12 +207,6 @@ GroupForm.propTypes = {
 
 const mapStateToProps = state => ({
     group: state.currentItem,
-    initialValues: {
-        [NAME]: state.currentItem[NAME],
-        [CODE]: state.currentItem[CODE],
-        [USERS]: asArray(state.currentItem[USERS]),
-        [MANAGED_GROUPS]: asArray(state.currentItem[MANAGED_GROUPS]),
-    },
 });
 
 const ReduxFormWrappedGroupForm = reduxForm({

--- a/src/containers/GroupForm/GroupForm.js
+++ b/src/containers/GroupForm/GroupForm.js
@@ -77,8 +77,8 @@ class GroupForm extends Component {
 
         group[NAME] = values[NAME];
         group[CODE] = values[CODE];
-        group[USERS] = values[USERS].map(this.createIdValueObject);
-        group[MANAGED_GROUPS] = values[MANAGED_GROUPS].map(this.createIdValueObject);
+        group[USERS] = (values[USERS] || []).map(this.createIdValueObject);
+        group[MANAGED_GROUPS] = (values[MANAGED_GROUPS] || []).map(this.createIdValueObject);
         group.attributeValues = parseAttributeValues(values, this.state.attributeFields);
 
         try {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -136,13 +136,11 @@ export const userGroupFormInitialValuesSelector = _.memoize(
     (userGroup, attributeFields) => {
         const initialValues = {};
 
-        if (userGroup.id) {
-            USER_GROUP_FIELDS.forEach(field => {
-                addInitialValueFrom(userGroup, initialValues, field.name);
-            });
+        USER_GROUP_FIELDS.forEach(field => {
+            addInitialValueFrom(userGroup, initialValues, field.name);
+        });
 
-            attributeFields.forEach(field => (initialValues[field.name] = field.value));
-        }
+        attributeFields.forEach(field => (initialValues[field.name] = field.value));
 
         return initialValues;
     }


### PR DESCRIPTION
- This bug was introduced in #39. 
- The Group form is now fetching some stuff at CDM and then setting the initial form values. 
- Before #39 it was setting the initialValues in `mapStateToProps` and the `asArray` helper returns an empty array for undefined values. 
- As a result the initial value for users and managed groups would be an empty array for new user-groups.
- The new setup uses a selector function which would only set initial values when editing a user group. So for new user-groups, the managed groups value would be undefined until the field was updated by the user. Not good, because this is an optional field
- So now, I am setting the initial values in the context of a new user-group too.
- And I've removed the section that would set the initial values in `mapStateToProps`. This should have really been done in #39 already, but I missed this.