### PR TITLE
DHIS2-5556 Unique attributes rendered as DropDown

### DIFF
--- a/src/utils/fieldRenderers.js
+++ b/src/utils/fieldRenderers.js
@@ -72,15 +72,30 @@ export const renderCheckbox = ({ input, label }) => {
     );
 };
 
-export const renderSelectField = ({ input, label, options, style }) => {
+export const renderSelectField = ({
+    input,
+    label,
+    meta: { touched, error, asyncValidating },
+    options,
+    style,
+}) => {
+    const errorText = asyncValidating ? i18n.t('Validating...') : touched && error;
+    const errorStyle = asyncValidating ? styles.warning : undefined;
+
     return (
         <SelectField
             floatingLabelText={label}
             fullWidth={true}
             {...input}
-            onChange={(event, index, value) => input.onChange(value)}
-            onBlur={() => input.onBlur(input.value)}
+            onChange={(event, index, value) => {
+                input.onChange(value);
+                // Trigger onBlur after a value is selected, in order to trigger
+                // a validator to run if the SelectField is in the asyncBlurFields list
+                setTimeout(() => input.onBlur(value), 1);
+            }}
             style={style}
+            errorText={errorText}
+            errorStyle={errorStyle}
         >
             {options.map(({ id, label }, i) => (
                 <MenuItem key={`option_${i}`} value={id} primaryText={label} />


### PR DESCRIPTION
## Problem 1
- If an attribute is required to be unique, then these fields are added to the ReduxForm asyncBlurFields array
- Whenever a field in this array is blurred, the asyncValidator will run.
- However, the version of MUI SelectField in use is not firing a blur after an option is selected

## Problem 2
- Prior to the introduction of attribute-fields into the user-app, there was no need to show error messages below SelectFields yet (no required fields were rendered as a dropdown, and invalid values were not possible)
- As a result, the field-renderer `renderSelectField` hadn't implemented displaying error messages

## Fix
1. The field-renderer `renderSelectField` will now show an orange warning whilst validating, and a red error text when there is an error
2. After `onChange` is called on the input element, the input's onBlur handler is also called, once the call stack has cleared.