### PR TITLE
DHIS2-4659: User administration does not support multiple OU roots

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -268,7 +268,7 @@ class Api {
             this.d2.currentUser.getUserGroups(),
             this.d2.currentUser.getUserRoles(),
             this.getCurrentUserOrgUnits(),
-            this.getSystemOrgUnitRoot(),
+            this.getSystemOrgUnitRoots(),
         ]).then(
             ([
                 userGroups,
@@ -278,7 +278,7 @@ class Api {
                     dataViewOrganisationUnits,
                     teiSearchOrganisationUnits,
                 },
-                systemOrganisationUnitRoot,
+                systemOrganisationUnitRoots,
             ]) => {
                 return Object.assign(this.d2.currentUser, {
                     userGroups,
@@ -286,7 +286,7 @@ class Api {
                     organisationUnits,
                     dataViewOrganisationUnits,
                     teiSearchOrganisationUnits,
-                    systemOrganisationUnitRoot,
+                    systemOrganisationUnitRoots,
                 });
             }
         );
@@ -324,7 +324,7 @@ class Api {
         );
     };
 
-    getSystemOrgUnitRoot = () => {
+    getSystemOrgUnitRoots = () => {
         return this.d2.models.organisationUnits
             .list({
                 paging: false,
@@ -332,7 +332,7 @@ class Api {
                 fields: 'id,path,displayName,children::isNotEmpty',
             })
             .then(modelCollection => {
-                return modelCollection.toArray()[0];
+                return modelCollection.toArray();
             });
     };
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -167,13 +167,13 @@ export const shortItemSelector = _.memoize((id, list) => {
  * @function
  */
 export const orgUnitRootsSelector = (orgUnitType, currentUser) => {
-    const systemOrgRoot = currentUser.systemOrganisationUnitRoot;
+    const systemOrgRoots = currentUser.systemOrganisationUnitRoots;
     const requestedOrgUnitRoots = currentUser[orgUnitType];
     const fallBackOrgUnitRoots = currentUser[DATA_CAPTURE_AND_MAINTENANCE_ORG_UNITS];
 
     let orgUnitRoots = null;
     if (currentUser.authorities.has('ALL')) {
-        orgUnitRoots = [systemOrgRoot];
+        orgUnitRoots = systemOrgRoots;
     } else if (requestedOrgUnitRoots.size === 0) {
         orgUnitRoots = fallBackOrgUnitRoots.toArray();
     } else if (fallBackOrgUnitRoots.size > 0) {


### PR DESCRIPTION
Some background info:
- Previously, we encountered a situation where a superuser (having the `ALL` authority) had not been assigned to the root organisation. That user would be unable to manage users properly, because he could not access the whole OrgunitTree.
- To combat that, I introduced an exception in the `orgUnitRootsSelector` which would assign THE (as in only 1) OrgUnitRoot to users with the `ALL` authority
- Now it has come to light that it is possible to have organisations with multiple OrgUnitRoots...

Steps to test the fix:
1. Download [XML file](https://jira.dhis2.org/secure/attachment/13460/organisationUnits-dual_root_2.xml) from the issue description
2. Go to the import-export-app in your local dhis2-core instance and import the XML file (choose Metadata import and select XML)
3. Log in as the `system` user, and visit the user-app within your local installation. Start editing a user, and in the form you will only see 1 OrgUnitRoot
4. Now run this branch of the user-app and visit the same edit form. You should see 2 OrgUnitRoots now.

Notes:
- I had a problem importing the XML file first and had to update my local instance of dhis2-core
- If you are seeing a problem with the icon fonts in my branch, please ignore this. I started this branch from a `git merge-base master v30` because it needs to be backported. Somehow an issue I fixed a while ago is present there....

