### PR TITLE
Fix unique attribute check

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,6 +9,7 @@ import {
     mapLocale,
     appendUsernameToDisplayName,
     parse200Error,
+    getAttributesWithValueAndId,
 } from './utils';
 
 import groupAuthorities from '../components/AuthorityEditor/utils/groupAuthorities';
@@ -191,6 +192,8 @@ class Api {
                 .on('id')
                 .notEqual(modelId)
                 // Attribute id being validated
+                // NB: this only means we are filtering users that have ANY value
+                // on the current attributeId
                 .filter()
                 .on('attributeValues.attribute.id')
                 .equals(attributeId)
@@ -198,10 +201,26 @@ class Api {
                 .filter()
                 .on('attributeValues.value')
                 .equals(value)
-                // Smallest response payload possible
-                .list({ paging: false, fields: ['id'] })
-                // Only unique if none is found
-                .then(modelCollection => modelCollection.size === 0)
+                .list({
+                    paging: false,
+                    fields: ['id', 'attributeValues[value, attribute[id]]'],
+                })
+                .then(userCollection => {
+                    // If no users are found at this point, the attribute value is definitely unique
+                    if (userCollection.size === 0) {
+                        return true;
+                    }
+
+                    // If users are returned, this can still include records with the SAME value
+                    // on ANOTHER attribute. So we have to filter on the current value and attributeId
+                    const attributesWithValueAndId = getAttributesWithValueAndId(
+                        userCollection,
+                        value,
+                        attributeId
+                    );
+
+                    return attributesWithValueAndId.length === 0;
+                })
         );
     }
 

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -224,3 +224,19 @@ export const parse200Error = response => {
     }
     return { messages };
 };
+
+export const getAttributesWithValueAndId = (userCollection, value, attributeId) =>
+    userCollection
+        .toArray()
+        .reduce(
+            (list, user) =>
+                list.concat(
+                    list,
+                    user.attributeValues.filter(
+                        attributeValue =>
+                            value === attributeValue.value &&
+                            attributeId === attributeValue.attribute.id
+                    )
+                ),
+            []
+        );

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -231,7 +231,6 @@ export const getAttributesWithValueAndId = (userCollection, value, attributeId) 
         .reduce(
             (list, user) =>
                 list.concat(
-                    list,
                     user.attributeValues.filter(
                         attributeValue =>
                             value === attributeValue.value &&


### PR DESCRIPTION
What was happening was the following:
- I was doing a query which, I thought, would only return users with a given value on a given attribute id
- But it turned out that it returned users that had ANY VALUE on a particular attribute ID, and matched the given value on ANY ATTRIBUTE

I didn't find any way to solve this by updating the query, so instead I added an extra check on the client.

