### PR TITLE
feat(authorities): adds skip-data-import-audit authority

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-01-07T11:57:11.737Z\n"
-"PO-Revision-Date: 2019-01-07T11:57:11.737Z\n"
+"POT-Creation-Date: 2019-03-06T10:54:33.962Z\n"
+"PO-Revision-Date: 2019-03-06T10:54:33.962Z\n"
 
 msgid "Use database locale / no translation"
 msgstr ""
@@ -207,6 +207,9 @@ msgid "Validation Rule"
 msgstr ""
 
 msgid "Data predictor group"
+msgstr ""
+
+msgid "Skip data import audit"
 msgstr ""
 
 msgid "Apps"

--- a/src/components/AuthorityEditor/utils/authorityGroupNames.js
+++ b/src/components/AuthorityEditor/utils/authorityGroupNames.js
@@ -62,4 +62,5 @@ export default new Map([
     ['F_VALIDATIONRULEGROUP', i18n.t('Validation Rule Group')],
     ['F_VALIDATIONRULE', i18n.t('Validation Rule')],
     ['F_PREDICTORGROUP', i18n.t('Data predictor group')],
+    ['F_SKIP_DATA_IMPORT_AUDIT', i18n.t('Skip data import audit')],
 ]);

--- a/src/components/AuthorityEditor/utils/groupAuthorities.js
+++ b/src/components/AuthorityEditor/utils/groupAuthorities.js
@@ -102,6 +102,7 @@ const AUTHORITY_GROUPS = {
         'F_METADATA_EXPORT',
         'F_METADATA_IMPORT',
         'F_METADATA_MANAGE',
+        'F_SKIP_DATA_IMPORT_AUDIT',
     ]),
     system: new Set([
         'ALL',

--- a/src/locales/en/translations.json
+++ b/src/locales/en/translations.json
@@ -66,6 +66,7 @@
     "Validation Rule Group": "",
     "Validation Rule": "",
     "Data predictor group": "",
+    "Skip data import audit": "",
     "Apps": "",
     "Tracker": "",
     "Import-Export": "",


### PR DESCRIPTION
As you can see, this PR adds some configuration only:
- I've added a new authority key to the import/export section in `/utils/groupAuthorities.js`
- The rest is just translation stuff

And here is the result on screen:
![screenshot 2019-03-06 at 12 00 51](https://user-images.githubusercontent.com/353236/53876629-857cad00-4007-11e9-8114-6188b960e791.png)
