### PR TITLE
DHIS2-6498: User list should be ordered by first name, last name

### DIFF
--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -69,12 +69,13 @@ export const createListRequestData = (
         pageSize: DEFAULT_PAGE_SIZE,
         fields,
         page,
-        order: 'lastUpdated:desc',
+        order: 'name:asc',
     };
 
     if (entityName === USER && !isSuperUser(currentUser)) {
         requestData.userOrgUnits = true;
         requestData.includeChildren = true;
+        requestData.order = ['firstName:asc', 'surname:asc'];
     }
 
     if (query) requestData.query = query;

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -69,13 +69,12 @@ export const createListRequestData = (
         pageSize: DEFAULT_PAGE_SIZE,
         fields,
         page,
-        order: 'name:asc',
+        order: entityName === USER ? ['firstName:asc', 'surname:asc'] : 'name:asc',
     };
 
     if (entityName === USER && !isSuperUser(currentUser)) {
         requestData.userOrgUnits = true;
         requestData.includeChildren = true;
-        requestData.order = ['firstName:asc', 'surname:asc'];
     }
 
     if (query) requestData.query = query;


### PR DESCRIPTION
This changes the list ordering in the user app. One thing that I am little unsure about is how I am setting the order for the user-lists: `order: ['firstName:asc', 'surname:asc']`...
This type of usage is not documented ([see docs](https://docs.dhis2.org/master/en/developer/html/dhis2_developer_manual_full.html#webapi_browsing_the_web_api)) but it does work.

I wouldn't really know how to do it in another way, because adding a second order query parameter via the d2 api get method would mean creating an object with duplicate keys.

I tried to start a discussion in the webapi Slack channel to get confirmation about the method I've used, but nobody replied....