### PR TITLE
fix: translations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,10 @@ const { REACT_APP_DHIS2_BASE_URL } = process.env
  * @function
  */
 
-const setupD2 = async () => {
+const setupD2 = () => {
+    const baseUrl = `${REACT_APP_DHIS2_BASE_URL}/api/`
     const initConfig = {
-        baseUrl: `${REACT_APP_DHIS2_BASE_URL}/api/`,
+        baseUrl,
         schemas: [
             'userRole',
             'user',
@@ -27,13 +28,11 @@ const setupD2 = async () => {
             'organisationUnit',
         ],
     }
+    config.baseUrl = baseUrl
 
-    const d2 = await init(initConfig)
-    const userSettings = await getUserSettings()
-
-    configI18n(userSettings)
-
-    return d2
+    return getUserSettings()
+        .then(configI18n)
+        .then(({ i18n }) => init({ ...initConfig, i18n }))
 }
 
 /**
@@ -52,6 +51,7 @@ const configI18n = userSettings => {
     }
     sources.add('i18n/i18n_module_en.properties')
     i18n.changeLanguage(uiLocale)
+    return config
 }
 
 /**


### PR DESCRIPTION
There was a regression after https://github.com/dhis2/user-app/pull/57 which broke translations in the old d2-ui components.
Now we are taking the following steps, which seems to work:
- First set config.baseUrl directly, this makes the first call to getUserSettings work, because that looks at the `preInitConfig.baseUrl`
- Secondly add the translation sources from the app to d2 config object, so they can be applied correctly when d2 initializes
- And lastly `d2.init` is called with that config object