### PR TITLE
fix(user-section): allow uppercase in email validation

### DIFF
--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -27,7 +27,7 @@ export function date(value) {
 }
 
 export function email(value) {
-    if (hasValue(value) && !EMAIL_ADDRESS_PATTERN.test(value)) {
+    if (hasValue(value) && !EMAIL_ADDRESS_PATTERN.test(value.toLowerCase())) {
         return i18n.t('Please provide a valid email address')
     }
 }


### PR DESCRIPTION
Previously, email validation was returning an error on uppercased email addresses. These are case-insensitive, so that was wrong. Instead of editing the regex, I opted to just cast the value to lowercase before testing the regex.