### PR TITLE
fix: include all owned fields when getting group and role

### DIFF
--- a/src/constants/queryFields.js
+++ b/src/constants/queryFields.js
@@ -33,26 +33,9 @@ export const USER_DETAILS = [
     'twitter',
 ]
 
-export const USER_ROLE_DETAILS = [
-    'id',
-    'access',
-    'displayName',
-    'name',
-    'users',
-    'description',
-    'authorities',
-]
+export const USER_ROLE_DETAILS = [':owner', 'authorities', 'displayName']
 
-export const USER_GROUP_DETAILS = [
-    'id',
-    'code',
-    'access',
-    'displayName',
-    'name',
-    'users',
-    'managedGroups',
-    'attributeValues',
-]
+export const USER_GROUP_DETAILS = [':owner', 'displayName']
 
 export const CURRENT_USER_ORG_UNITS_FIELDS = {
     fields: [


### PR DESCRIPTION
### Context
- The User App uses `d2`
- In edit mode, the `userRole` and `userGroup` forms are triggering a `PUT` request via `d2`:
    - The `userRole` form triggers the `api.update` method
    - The `userGroup` form triggers `userGroup.save`
    - One of the above auto-appends `mergeMode=REPLACE`, but this is the default, so the behaviour of both is identical.
- When doing a PUT requests, the webapi will clear the values from the "owned" fields that are not included in the payload.
- To prevent this behaviour, we can always include all `:owned` fields in the GET request field filter and PUT payload <sup>[*](#footnote_1)</sup>.
- Since `authorities` and `displayName` were not technically "owned" fields, they had to be added explicitly.
- I did not have to touch the UserForm, because that was already using the `:owned` field filter

<a name="footnote_1">*</a> _I established this was the appropriate approach by consulting the[ **Field presets** section of the MetaData field chapter in the developer manual](
https://docs.dhis2.org/master/en/developer/html/dhis2_developer_manual_full.html#webapi_metadata_field_filter), and then confirming with Viet._