### PR TITLE
fix(replicate-user): add autocomplete="new-password" to prevent autofill

### DIFF
--- a/src/components/ReplicateUserForm.js
+++ b/src/components/ReplicateUserForm.js
@@ -78,6 +78,7 @@ class ReplicateUserForm extends Component {
                     label={i18n.t('Username')}
                     hintText={i18n.t('Username for new user')}
                     validate={[username]}
+                    autoComplete="new-password"
                 />
                 <Field
                     name={PASSWORD}
@@ -86,6 +87,7 @@ class ReplicateUserForm extends Component {
                     hintText={i18n.t('Password for new user')}
                     validate={[password]}
                     type="password"
+                    autoComplete="new-password"
                 />
                 <div style={{ marginTop: 16 }}>
                     <RaisedButton


### PR DESCRIPTION
Despite having set autocomplete to "off" on the form, Chrome was still happily filling both the username **and the password** field. 

For the password field, this makes sense because the field-name is `password`. And it's quite well documented that browsers will ignore `autocomplete="off"` for these.... So this was just an oversight from me...

The fact that the username was also being pre-filled was a bit of a mystery too me.... I found [this stackoverflow post](https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off), which mentioned:
> In my experience, Chrome only autocompletes the first <input type="password"> *and the previous <input>*.

This could be the reason why the username field was being autofilled too....

In any case, I decided to add `autocomplete="new-password"` to the username field too. It might not be strictly speaking required, but it won't hurt either.

NB: Personally I found it impossible to activate browser autofill on the development domain (localhost:3000) because it has no login window, so I have verified that this solution works by doing a "local deployment". I can confirm that auto-fill stopped after the changes below.