### PR TITLE
fix(authorities): add visualization and remove report-table and chart

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-26T10:14:31.500Z\n"
-"PO-Revision-Date: 2019-09-26T10:14:31.500Z\n"
+"POT-Creation-Date: 2020-02-25T08:03:52.805Z\n"
+"PO-Revision-Date: 2020-02-25T08:03:52.805Z\n"
 
 msgid "User management"
 msgstr ""
@@ -60,9 +60,6 @@ msgid "Category Option Group"
 msgstr ""
 
 msgid "Category Option Group Set"
-msgstr ""
-
-msgid "Chart"
 msgstr ""
 
 msgid "Color Set"
@@ -170,9 +167,6 @@ msgstr ""
 msgid "Relationship Type"
 msgstr ""
 
-msgid "Report Table"
-msgstr ""
-
 msgid "Report"
 msgstr ""
 
@@ -213,6 +207,9 @@ msgid "Data predictor group"
 msgstr ""
 
 msgid "Skip data import audit"
+msgstr ""
+
+msgid "Visualization"
 msgstr ""
 
 msgid "Apps"

--- a/src/components/AuthorityEditor/utils/authorityGroupNames.js
+++ b/src/components/AuthorityEditor/utils/authorityGroupNames.js
@@ -9,7 +9,6 @@ export default new Map([
     ['F_CATEGORY_OPTION', i18n.t('Category Option')],
     ['F_CATEGORY_OPTION_GROUP', i18n.t('Category Option Group')],
     ['F_CATEGORY_OPTION_GROUP_SET', i18n.t('Category Option Group Set')],
-    ['F_CHART', i18n.t('Chart')],
     ['F_COLOR_SET', i18n.t('Color Set')],
     ['F_CONSTANT', i18n.t('Constant')],
     ['F_DASHBOARD', i18n.t('Dashboard')],
@@ -48,7 +47,6 @@ export default new Map([
     ],
     ['F_PUSH_ANALYSIS', i18n.t('Push Analysis')],
     ['F_RELATIONSHIPTYPE', i18n.t('Relationship Type')],
-    ['F_REPORTTABLE', i18n.t('Report Table')],
     ['F_REPORT', i18n.t('Report')],
     ['F_SECTION', i18n.t('Section')],
     ['F_SQLVIEW', i18n.t('SQL View')],
@@ -63,4 +61,5 @@ export default new Map([
     ['F_VALIDATIONRULE', i18n.t('Validation Rule')],
     ['F_PREDICTORGROUP', i18n.t('Data predictor group')],
     ['F_SKIP_DATA_IMPORT_AUDIT', i18n.t('Skip data import audit')],
+    ['F_VISUALIZATION', i18n.t('Visualization')],
 ])

--- a/src/components/AuthorityEditor/utils/groupAuthorities.js
+++ b/src/components/AuthorityEditor/utils/groupAuthorities.js
@@ -71,12 +71,18 @@ const IMPLICIT_GROUP_ITEM = {
 
 // Metadata with implicit add and delete
 const AUTHS_WITH_IMPLICIT_ADD_PRIVATE_AND_DELETE = new Set([
-    'F_CHART_PUBLIC_ADD',
     'F_DASHBOARD_PUBLIC_ADD',
     'F_EVENTCHART_PUBLIC_ADD',
     'F_EVENTREPORT_PUBLIC_ADD',
     'F_MAP_PUBLIC_ADD',
+    'F_VISUALIZATION_PUBLIC_ADD',
+])
+
+const DEPRECATED_AUTHS = new Set([
+    'F_CHART_PUBLIC_ADD',
+    'F_CHART_EXTERNAL',
     'F_REPORTTABLE_PUBLIC_ADD',
+    'F_REPORTTABLE_EXTERNAL',
 ])
 
 const AUTHORITY_GROUPS = {
@@ -144,7 +150,9 @@ const AUTHORITY_GROUPS = {
 const groupAuthorities = authorities => {
     // A lookup map that can be used to verify the existence of a particular authority ID in linear time
     const lookup = authorities.reduce((lookup, auth) => {
-        lookup.set(auth.id, auth)
+        if (!DEPRECATED_AUTHS.has(auth.id)) {
+            lookup.set(auth.id, auth)
+        }
         return lookup
     }, new Map())
 

--- a/src/components/AuthorityEditor/utils/groupAuthorities.js
+++ b/src/components/AuthorityEditor/utils/groupAuthorities.js
@@ -78,13 +78,6 @@ const AUTHS_WITH_IMPLICIT_ADD_PRIVATE_AND_DELETE = new Set([
     'F_VISUALIZATION_PUBLIC_ADD',
 ])
 
-const DEPRECATED_AUTHS = new Set([
-    'F_CHART_PUBLIC_ADD',
-    'F_CHART_EXTERNAL',
-    'F_REPORTTABLE_PUBLIC_ADD',
-    'F_REPORTTABLE_EXTERNAL',
-])
-
 const AUTHORITY_GROUPS = {
     tracker: new Set([
         'F_PROGRAM_DASHBOARD_CONFIG_ADMIN',
@@ -150,9 +143,7 @@ const AUTHORITY_GROUPS = {
 const groupAuthorities = authorities => {
     // A lookup map that can be used to verify the existence of a particular authority ID in linear time
     const lookup = authorities.reduce((lookup, auth) => {
-        if (!DEPRECATED_AUTHS.has(auth.id)) {
-            lookup.set(auth.id, auth)
-        }
+        lookup.set(auth.id, auth)
         return lookup
     }, new Map())
 


### PR DESCRIPTION
#### A general note:
I'm pretty sure I've interpreted and fixed this issue correctly. However, I did make quite a few assumptions which should still be confirmed by @larshelge, see [this issue comment](https://jira.dhis2.org/browse/DHIS2-8148?focusedCommentId=30875&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30875).

#### Changes in the UI after this PR:
- The Report table and Chart authority are gone
- The Visualizations authority has been added

#### A note about the code:
Since the endpoint is still returning the old authorities I needed to explicitly ignore them