### PR TITLE
fix(translation): prevent JS error in list view for Indonesian language

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@dhis2/ui-core": "^4.1.2",
     "@dhis2/ui-widgets": "^2.0.5",
     "d2": "31.0.1",
-    "d2-ui": "29.0.25",
+    "d2-ui": "^29.0.35",
     "d2-utilizr": "^0.2.15",
     "d3-color": "^1.0.3",
     "lodash.capitalize": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3806,10 +3806,10 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-d2-ui@29.0.25:
-  version "29.0.25"
-  resolved "https://registry.yarnpkg.com/d2-ui/-/d2-ui-29.0.25.tgz#122c804f8bf2a3c57df509c1fa1b6e956dffe790"
-  integrity sha512-bKApeX8lUlkDBSNUSghlnCLTpB7fvFlO4VgqoFDs48/uiJI2YBL5KlpEVzz+U3MdLfw9LV8Mez/NiCxR2Ijerg==
+d2-ui@^29.0.35:
+  version "29.0.35"
+  resolved "https://registry.yarnpkg.com/d2-ui/-/d2-ui-29.0.35.tgz#b0f8540957e90ded7bf2257bbd2604b7b8034c0c"
+  integrity sha512-NS4YXUdDti5igBLAT+IdWnQeAygf/m2ubG8+nakkrKhP4RHGgwuZmKveLKkpmbZDATvE4Dz/0DLnTaP+/ZLgaA==
 
 d2-utilizr@^0.2.15:
   version "0.2.16"


### PR DESCRIPTION
Relates to DHIS2-7698

This PR updates the d2-ui library from 29.0.34 to 29.0.35, which has a quick fix for the Indonesian locale with underscore.