### PR TITLE
fix(user): allow clearing string values

### DIFF
--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -168,7 +168,10 @@ export const parseUserSaveData = (
     // This is only required when editing users, because new users can't have such properties
     if (!isNewUser) {
         for (const ownedPropName of userModelOwnedProperties) {
-            if (user[ownedPropName] && !data[ownedPropName]) {
+            if (
+                user[ownedPropName] &&
+                typeof data[ownedPropName] === 'undefined'
+            ) {
                 data[ownedPropName] = user[ownedPropName]
             }
         }

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -168,10 +168,7 @@ export const parseUserSaveData = (
     // This is only required when editing users, because new users can't have such properties
     if (!isNewUser) {
         for (const ownedPropName of userModelOwnedProperties) {
-            if (
-                user[ownedPropName] &&
-                typeof data[ownedPropName] === 'undefined'
-            ) {
+            if (user[ownedPropName] && !(ownedPropName in data)) {
                 data[ownedPropName] = user[ownedPropName]
             }
         }


### PR DESCRIPTION
This is a fix that resolves an issue in a workaround, so I guess a little explanation will help 🤦‍♂ 

Originally we had a problem with some fields being cleared that hadn't been touched (or actually weren't even on the form), when updating a user. This problem is due to the fact that we are doing a PUT request here. A PATCH would have been a much better fit, but since the users resource has limited support for PATCH this was a no-go. 

So to fix the original problem, I just looped through all the user fields and appended missing user-properties to the form object from the user object.

There was a problem in the condition I was originally using: I was using this condition to identify user-fields that needed to be appended to the form: `user[ownedPropName] && !data[ownedPropName]`. But if the form-value was an empty string, and the user-value was a non-empty string, this would also return true. So for example, if a user would have a skype address specified, and then this value was cleared on the edit form, the condition would be true and the form-value would get populated with the user-value, effectively undoing the edit.

So to resolve this I have changed the condition and am now only copying the user-value to the form-value if the form-value is `undefined`.

https://github.com/dhis2/user-app/blob/71da77c45571c325d4b904dca9574a218e63455f/src/api/utils.js#L166-L178