### PR TITLE
fix(user): make ui and db locale field required and prevent clear onBlur

### DIFF
--- a/src/containers/UserForm/config.js
+++ b/src/containers/UserForm/config.js
@@ -230,12 +230,14 @@ export const BASE_FIELDS = [
         label: i18n.t('Interface language'),
         fieldRenderer: renderSelectField,
         optionsSelector: 'locales.ui.available',
+        isRequiredField: ALWAYS_REQUIRED,
     },
     {
         name: DATABASE_LANGUAGE,
         label: i18n.t('Database language'),
         fieldRenderer: renderSelectField,
         optionsSelector: 'locales.db.available',
+        isRequiredField: ALWAYS_REQUIRED,
     },
     {
         name: ASSIGNED_ROLES,

--- a/src/utils/fieldRenderers.js
+++ b/src/utils/fieldRenderers.js
@@ -90,7 +90,8 @@ export const renderSelectField = ({
         <SelectField
             floatingLabelText={label}
             fullWidth={true}
-            {...input}
+            value={input.value}
+            name={input.name}
             onChange={(event, index, value) => {
                 input.onChange(value)
                 // Trigger onBlur after a value is selected, in order to trigger


### PR DESCRIPTION
## TL;DR;
This fix makes the `uiLocale` and `dbLocale` mandatory and prevents the selects from being cleared when tabbing over them. This will prevent the errors from happening under normal circumstances, but a server-side fix is needed to completely fix this issue.

## Details

See Slack for some details about this issue https://dhis2.slack.com/archives/CPGUFVC56/p1586163586145200

You could say that there are 3 parts to fixing this completely, and the current PR fixes 1 and 2:
1. Prevent Selects from being cleared when tabbing over them. This was happening because I was spreading the `input` prop on the Select and the `onBlur` and `onFocus` handlers were causing issues, and were not really required to begin with. **This is fixed in the current PR**, see `src/utils/fieldRenderers.js`.
2. Make keyUiLocale and keyDbLocale mandatory. Even if a user finds a way to unset these selects, they will not be allowed to click save. **This is fixed in the PR**, see `src/containers/UserForm/config.js`
3. Currently we are doing one request to update the `user` (incl. `userCredentials`) and two follow-up requests to update the locales. This can create scenarios where a request is "partially successful". **This problem has not been addressed in the current PR**. Instead we have created [a JIRA issue](https://jira.dhis2.org/browse/DHIS2-8601) for adding support to set the `uiLocale` and `dbLocale` via the `users` endpoint.