### PR TITLE
fix: identified static strings and made them translatable

### DIFF
--- a/src/constants/routeConfig.js
+++ b/src/constants/routeConfig.js
@@ -16,7 +16,7 @@ const USER_SECTION = {
     label: i18n.t('User'),
     icon: 'person',
     path: '/users',
-    description: 'Create, modify, view and delete Users',
+    description: i18n.t('Create, modify, view and delete Users'),
     component: UserList,
     entityType: USER,
 }
@@ -25,7 +25,7 @@ const USER_ROLE_SECTION = {
     label: i18n.t('User role'),
     icon: 'folder_shared',
     path: '/user-roles',
-    description: 'Create, modify, view and delete User Roles',
+    description: i18n.t('Create, modify, view and delete User Roles'),
     component: RoleList,
     entityType: USER_ROLE,
 }
@@ -34,7 +34,7 @@ const USER_GROUP_SECTION = {
     label: i18n.t('User group'),
     icon: 'group',
     path: '/user-groups',
-    description: 'Create, modify, view and delete User Groups',
+    description: i18n.t('Create, modify, view and delete User Groups'),
     component: GroupList,
     entityType: USER_GROUP,
 }

--- a/src/containers/UserForm/config.js
+++ b/src/containers/UserForm/config.js
@@ -120,11 +120,11 @@ export const INVITE_FIELDS = [
         options: [
             {
                 id: SET_PASSWORD,
-                label: 'Create account with user details',
+                label: i18n.t('Create account with user details'),
             },
             {
                 id: INVITE_USER,
-                label: 'Email invitation to create account',
+                label: i18n.t('Email invitation to create account'),
             },
         ],
         props: {


### PR DESCRIPTION
Disclaimer:
I couldn't really think of a fully reliable way to find _all static strings_. I attempted doing a generic search on quotation marks but that yielded way too many results to be useful. So instead I just did some case-insensitive searches for words that may signal a translatable string. I tried `label`, `description`, `name`, `displayname`,  `msg` and `message`....

I found 5 strings that needed to become translatable, but cannot be sure I've caught them all. If you can think of a more reliable way to identify them, please let me know and I'll take another stab at this.