### PR TITLE
fix(translations): produce and stage pot files in pre-commit hook

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-02-25T08:03:52.805Z\n"
-"PO-Revision-Date: 2020-02-25T08:03:52.805Z\n"
+"POT-Creation-Date: 2020-05-04T13:32:28.331Z\n"
+"PO-Revision-Date: 2020-05-04T13:32:28.331Z\n"
 
 msgid "User management"
 msgstr ""
@@ -383,10 +383,19 @@ msgstr ""
 msgid "Number of users"
 msgstr ""
 
+msgid "Create, modify, view and delete Users"
+msgstr ""
+
 msgid "User role"
 msgstr ""
 
+msgid "Create, modify, view and delete User Roles"
+msgstr ""
+
 msgid "User group"
+msgstr ""
+
+msgid "Create, modify, view and delete User Groups"
 msgstr ""
 
 msgid "Could not load the user group data. Please refresh the page."
@@ -467,6 +476,12 @@ msgid ""
 msgstr ""
 
 msgid "Create account or email invitation"
+msgstr ""
+
+msgid "Create account with user details"
+msgstr ""
+
+msgid "Email invitation to create account"
 msgstr ""
 
 msgid "External authentication only (OpenID or LDAP)"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "d2-style commit check",
-      "pre-commit": "d2-style js apply && npm run localize && git add ./i18n"
+      "pre-commit": "d2-style js apply && npm run localize && git add :/i18n"
     }
   },
   "greenkeeper": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "d2-style commit check",
-      "pre-commit": "d2-style js apply"
+      "pre-commit": "d2-style js apply && npm run localize && git add ./i18n"
     }
   },
   "greenkeeper": {


### PR DESCRIPTION
Updated `.pot` files for this app were created during the build, but these files actually do need to be committed for the transifex workflow. So I am now generating and staging them in the pre-commit husky hook.