### PR TITLE
fix(i18n): correct edit button text on DetailSummary

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-04T13:32:28.331Z\n"
-"PO-Revision-Date: 2020-05-04T13:32:28.331Z\n"
+"POT-Creation-Date: 2020-05-11T14:57:14.928Z\n"
+"PO-Revision-Date: 2020-05-11T14:57:14.928Z\n"
 
 msgid "User management"
 msgstr ""
@@ -231,6 +231,15 @@ msgid "list"
 msgstr ""
 
 msgid "You do not have access to any section of the DHIS 2 User Management App"
+msgstr ""
+
+msgid "Edit user"
+msgstr ""
+
+msgid "Edit user group"
+msgstr ""
+
+msgid "Edit user role"
 msgstr ""
 
 msgid "Send message"

--- a/src/components/DetailSummary.js
+++ b/src/components/DetailSummary.js
@@ -16,7 +16,7 @@ import RaisedButton from 'material-ui/RaisedButton'
 import ImageEdit from 'material-ui/svg-icons/image/edit'
 import ContentSend from 'material-ui/svg-icons/content/send'
 import { Link } from 'react-router-dom'
-import { USER } from '../constants/entityTypes'
+import { USER, USER_GROUP, USER_ROLE } from '../constants/entityTypes'
 import { connect } from 'react-redux'
 import { getItem } from '../actions'
 
@@ -54,6 +54,19 @@ class DetailSummary extends Component {
     componentDidMount() {
         const { baseName, routeId, getItem } = this.props
         getItem(baseName, routeId)
+    }
+
+    getLabelForEntity(baseName) {
+        switch (baseName) {
+            case USER:
+                return i18n.t('Edit user')
+            case USER_GROUP:
+                return i18n.t('Edit user group')
+            case USER_ROLE:
+                return i18n.t('Edit user role')
+            default:
+                return ''
+        }
     }
 
     /**
@@ -162,7 +175,7 @@ class DetailSummary extends Component {
             baseRoute = `/${kebabCase(plural)}`,
             backTooltip = i18n.t(`Back to ${plural}`),
             editLink = `${baseRoute}/edit/${id}`,
-            editTooltip = i18n.t(`Edit ${baseName}`)
+            editLabel = this.getLabelForEntity(baseName)
 
         return (
             <main style={styles.main}>
@@ -177,7 +190,7 @@ class DetailSummary extends Component {
                     {access.update ? (
                         <RaisedButton
                             style={styles.raisedButton}
-                            label={editTooltip}
+                            label={editLabel}
                             primary={true}
                             containerElement={<Link to={editLink} />}
                             icon={<ImageEdit />}


### PR DESCRIPTION
This is a follow-up on https://github.com/dhis2/user-app/pull/480 because the testers found one string that wasn't translatable. 

The branch name and and first commit message could be a bit confusing. There were actually two things going wrong:
- Before this fix I was trying to combine a client-side-translated string ("Edit") with what I thought was a server-side-translated string (i.e. user / user-group / user-role)
- To do this I was using a template literal, when I should have been using the i18n interpolation syntax.
- However, after I fixed that in https://github.com/dhis2/user-app/commit/fb4614dd1a6cf2d3dda86cd14f8340a4b3c45c96, I noticed that actually the `baseName` wasn't a server-side-translated string at all. Its value was just one of the constants from `./src/constants/entityTypes.js`.
- Since i18n string interpolation was pretty useless here, I just changed it to a helper method that returns three hard-coded strings. This will make it easier to translate for the translators as well, since they now actually understand what they are translating (it said "Edit {{baseName}}" before, which doesn't provide any context)