### PR TITLE
fix(user): remove generateUid import and remove ids from POST payload

### DIFF
--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -5,7 +5,6 @@
  * @module Api/utils
  */
 
-import { generateUid } from 'd2'
 import snakeCase from 'lodash.snakecase'
 import isUndefined from 'lodash.isundefined'
 import store from '../store'
@@ -119,19 +118,23 @@ export const parseUserSaveData = (
     attributeFields
 ) => {
     const isNewUser = !user.id
-    const userId = user.id || generateUid()
-    const userCredId =
-        (user.userCredentials && user.userCredentials.id) || generateUid()
     const userModelOwnedProperties = user.modelDefinition.getOwnedPropertyNames()
-    const data = {
-        id: userId,
-        userCredentials: {
-            id: userCredId,
-            userInfo: { id: userId },
-            cogsDimensionConstraints: [],
-            catDimensionConstraints: [],
-        },
-    }
+    const data = isNewUser
+        ? {
+              userCredentials: {
+                  cogsDimensionConstraints: [],
+                  catDimensionConstraints: [],
+              },
+          }
+        : {
+              id: user.id,
+              userCredentials: {
+                  id: user.userCredentials && user.userCredentials.id,
+                  userInfo: { id: user.id },
+                  cogsDimensionConstraints: [],
+                  catDimensionConstraints: [],
+              },
+          }
     const cred = data.userCredentials
 
     // catCogsDimensionConstraints are combined into a single input component,


### PR DESCRIPTION
When porting to the app platform, the d2 dependency also got bumped a few minor versions. The newer version didn't include the `generateUid` helper anymore, and I was relying on this helper when creating a user. 

I'm not fully sure why I was generating uids in the client in the first place, I suspect it was needed at some point to ensure the `userCredentials` would be linked to the user correctly 🤷‍♂️ . In any case, I have simply removed the import and am not sending any IDs when POSTing. This seems to work fine: even without these IDs the `user` and `userCredentials` seem to be linked together just fine. I have verified that by checking that the value for a certain field called _"Available dimension restrictions for data analytics"_ (under _"more options"_) is correctly persisted. This field is part of the `userCredentials`, so if I am still seeing the correct value after a refresh I figured everything is working OK.

The only affected version is 2.36 because the port to the app-platform was done after the 2.35.0 code-freeze.