### PR TITLE
fix(group-editor): convert d2 Model to object before setting displayName

### DIFF
--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -225,12 +225,13 @@ export const getRestrictedOrgUnits = (orgUnits, orgUnitType) => {
     })
 }
 
-export const appendUsernameToDisplayName = userModelCollection => {
-    userModelCollection.forEach(user => {
-        user.displayName += ` (${user.userCredentials.username})`
+export const appendUsernameToDisplayName = userModelCollection =>
+    userModelCollection.toArray().map(userModel => {
+        const username = userModel.userCredentials.username
+        const user = userModel.toJSON()
+        user.displayName += ` (${username})`
+        return user
     })
-    return userModelCollection
-}
 
 export const parse200Error = response => {
     const messages = []


### PR DESCRIPTION
This is a super interesting demo of how `d2`s schema based behaviour works:

- There was a schema change on the `displayName` field:
    - 2.35dev => `"writable": true` [see 2.35 user schema](https://play.dhis2.org/2.35dev/api/schemas/user.json?fields=klass,displayName,properties[name,writable])
    - dev => `"writable": false` [see dev user schema](https://play.dhis2.org/dev/api/schemas/user.json?fields=klass,displayName,properties[name,writable])
- I was iterating through a `d2` `ModelCollection` of users and appending the `username` to the `displayName` before I fed this into the d2-ui `GroupEditor`
- But after this schema change d2 refuses to do this and will throw an error saying:
  `TypeError: Cannot set property displayName of #<Model> which has only a getter`
- Luckily the `GroupEditor` doesn't require a collection of `d2` `Models`, it can just work with plain JavaScript arrays just as well.
- So I fixed this by converting the ModelCollection into a array of object before setting the displayName field

Everything still works, because we're only including the user-ids when we PUT/POST, so it's not like we're really changing the user's displayName.

And there was one other quirk, I'll leave a comment in the code for that one.