### PR TITLE
fix: don't fetch unpaged members of current user groups (DHIS2-10377)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-07T13:38:29.494Z\n"
-"PO-Revision-Date: 2020-09-07T13:38:29.494Z\n"
+"POT-Creation-Date: 2021-02-11T14:12:34.322Z\n"
+"PO-Revision-Date: 2021-02-11T14:12:34.322Z\n"
 
 msgid "Use database locale / no translation"
 msgstr ""
@@ -491,6 +491,9 @@ msgid "Email invitation to create account"
 msgstr ""
 
 msgid "External authentication only (OpenID or LDAP)"
+msgstr ""
+
+msgid "Disabled"
 msgstr ""
 
 msgid "Retype password"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -351,16 +351,25 @@ class Api {
         return this.d2.currentUser
     }
 
+    getCurrentUserGroupsAndRoles = () => {
+        return this.d2Api
+            .get('me', {
+                fields: 'userGroups[id],userCredentials[userRoles[id]]',
+            })
+            .then(res => ({
+                userGroupIds: res.userGroups.map(({ id }) => id),
+                userRoleIds: res.userCredentials.userRoles.map(({ id }) => id),
+            }))
+    }
+
     initCurrentUser = () => {
         return Promise.all([
-            this.d2.currentUser.getUserGroups(),
-            this.d2.currentUser.getUserRoles(),
+            this.getCurrentUserGroupsAndRoles(),
             this.getCurrentUserOrgUnits(),
             this.getSystemOrgUnitRoots(),
         ]).then(
             ([
-                userGroups,
-                userRoles,
+                { userGroupIds, userRoleIds },
                 {
                     organisationUnits,
                     dataViewOrganisationUnits,
@@ -369,8 +378,8 @@ class Api {
                 systemOrganisationUnitRoots,
             ]) => {
                 return Object.assign(this.d2.currentUser, {
-                    userGroups,
-                    userRoles,
+                    userGroupIds,
+                    userRoleIds,
                     organisationUnits,
                     dataViewOrganisationUnits,
                     teiSearchOrganisationUnits,
@@ -385,9 +394,9 @@ class Api {
             .constructor
         const meFields = [
             ':all',
-            'organisationUnits[id]',
-            'userGroups[id]',
-            'userCredentials[:all,!user,userRoles[id]',
+            '!userGroups',
+            '!organisationUnits',
+            'userCredentials[:all,!user,!userRoles]',
         ]
         const models = this.d2.models
 

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -235,7 +235,7 @@ List.defaultProps = {
 const mapStateToProps = state => {
     return {
         listType: state.list.type,
-        items: listSelector(state.list.items, state.currentUser.userGroups),
+        items: listSelector(state.list.items, state.currentUser.userGroupIds),
         pager: pagerSelector(state.pager),
     }
 }

--- a/src/containers/GroupList/GroupList.js
+++ b/src/containers/GroupList/GroupList.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import List from '../../components/List'
 import i18n from '@dhis2/d2-i18n'
 import {
@@ -32,10 +31,4 @@ class GroupList extends Component {
     }
 }
 
-const mapStateToProps = state => {
-    return {
-        groupMemberships: state.currentUser.userGroups,
-    }
-}
-
-export default connect(mapStateToProps)(GroupList)
+export default GroupList

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -70,7 +70,7 @@ const listMappings = {
     },
     userRole: item => item,
     userGroup: (item, groupMemberships) => {
-        item.currentUserIsMember = Boolean(groupMemberships.includes(item.id))
+        item.currentUserIsMember = groupMemberships.includes(item.id)
         return item
     },
 }

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -70,7 +70,7 @@ const listMappings = {
     },
     userRole: item => item,
     userGroup: (item, groupMemberships) => {
-        item.currentUserIsMember = Boolean(groupMemberships.get(item.id))
+        item.currentUserIsMember = Boolean(groupMemberships.includes(item.id))
         return item
     },
 }

--- a/src/utils/detectCurrentUserChanges.js
+++ b/src/utils/detectCurrentUserChanges.js
@@ -29,11 +29,17 @@ const detectCurrentUserChanges = (model, disable) => {
         disable ? logout() : refreshCurrentUser()
     }
 
-    if (entityType === USER_ROLE && currentUser.userRoles.get(model.id)) {
+    if (
+        entityType === USER_ROLE &&
+        currentUser.userRoleIds.includes(model.id)
+    ) {
         refreshCurrentUser()
     }
 
-    if (entityType === USER_GROUP && currentUser.userGroups.get(model.id)) {
+    if (
+        entityType === USER_GROUP &&
+        currentUser.userGroupIds.includes(model.id)
+    ) {
         refreshCurrentUser()
     }
 }


### PR DESCRIPTION
This fixes a critical issue which occurred when loading the Users app in an instance containing 10s of thousands of users.  

This was caused by d2 overeagerly downloading all userGroups (including all their member users) for the current user when using the `d2.currentUser.getUserGroups()` method.  Since this app only ever used the `id` of the groups to determine membership, we can instead only download `userGroups[id]` from the `me` endpoint.  I went ahead and did the same for `userRoles` and removed a duplicated `organisationUnits` fetched by `me` and later from `/api/organisationUnits` - `userGroups` and `userRoles` and `organisationUnits` are all ignored by the d2 `currentUser` constructor (unless `getUserGroups` or `getUserRoles` is called), so this should be safe.

The design of `d2.currentUser` here is fraught with traps and poorly designed, it's long-since overdue to remove it.

NOTE: There still exists a critical issue *when editing a user group*, as that will fetch ALL users (as well as all assigned users) on startup, making group editing unusable.  We need to update the `SearchableGroupEditor` to send the filter to the server, rather than filtering on the client.  This issue is further exacerbated by a backend performance issue in the `userGroups/<id>` endpoint which causes all users to be fetched from the database even when `fields=!users` is passed ([DHIS2-10244](https://jira.dhis2.org/browse/DHIS2-10244)), but a frontend fix is also required - I will open a separate issue for that.  