### PR TITLE
fix(expiry date): do not parse empty initial state to date

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -94,7 +94,7 @@ const jsDateToISO8601 = date =>
         .padStart(2, 0)}-${date.getDate().toString().padStart(2, 0)}`
 
 const addInitialValueFrom = (sourceObject, initialValues, propName) => {
-    if (propName === EXPIRE_DATE) {
+    if (propName === EXPIRE_DATE && sourceObject[propName]) {
         const expiryDate = new Date(sourceObject[propName])
         const formattedDate = jsDateToISO8601(expiryDate)
         initialValues[propName] = formattedDate


### PR DESCRIPTION
Fixes DHIS2-10717 for 2.36dev (2.36.1)