### PR TITLE
fix(i18n): generate translations under the default namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild": "npm run localize",
     "pretest": "npm run localize",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
-    "localize": "npm run extract-pot && d2-i18n-generate -n user-app -p ./i18n/ -o ./src/locales/",
+    "localize": "npm run extract-pot && d2-i18n-generate -n default -p ./i18n/ -o ./src/locales/",
     "documentation": "rimraf build && jsdoc -c jsdoc.json"
   },
   "dependencies": {


### PR DESCRIPTION
`i18n` was broken on the v35 branch. Upon inspection the issue was identical to https://github.com/dhis2/scheduler-app/pull/164.

@ismay, would you mind merging this in yourself? I'm taking the rest of the day off.