### PR TITLE
fix: leave URI encoding to d2 API

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -135,8 +135,6 @@ class Api {
     }
 
     getSelectedAndAvailableLocales = username => {
-        username = username ? encodeURIComponent(username) : null
-
         const useDbLocaleOption = {
             id: USE_DB_LOCALE,
             label: i18n.t('Use database locale / no translation'),
@@ -145,6 +143,7 @@ class Api {
         const dbLocales = this.d2Api.get('/locales/db')
         const uiLocales = this.d2Api.get('/locales/ui')
 
+        // As of d2 v31.3.0, d2Api handles URI encoding
         const uiLocale = username
             ? this.d2Api.get(`/userSettings/keyUiLocale?user=${username}`)
             : this.d2.system.settings.get('keyUiLocale')
@@ -258,7 +257,7 @@ class Api {
             }
 
             const localePromises = []
-            const username = encodeURIComponent(values.username)
+            const username = values.username
 
             // Add follow-up request for setting uiLocale if needed
             const uiLocale = values[INTERFACE_LANGUAGE]


### PR DESCRIPTION
Fixes [Users with spaces in their usernames cannot be edited](https://jira.dhis2.org/browse/DHIS2-11528) - but I think **users with spaces in their usernames will still not be able to log in.** I think that's another issue with the login process

As of `d2` v31.3.0, the d2 API [handles URI encoding](https://github.com/dhis2/d2/commit/dd5203dd749254608e44e50cfd4200026f0becee#diff-6c0bd5dbc361d2b0c60228112b5dee87b6bc82e9818b31745588ee4b7b6fd1a4), and any encoding done before that causes the error seen in the associated bug report. Maybe that change to `d2` should have incremented the major version?

This PR also fixes the same bug if someone tries to edit the interface or database language of user with spaces in their username

v36 backport: #791 

Versions v35 and v34 don't exhibit this bug because they use `d2` v31.0.1 before URIs are encoded