### PR TITLE
fix: crash when user does not have view user-authority

### DIFF
--- a/src/components/SectionLoader.js
+++ b/src/components/SectionLoader.js
@@ -83,6 +83,11 @@ class SectionLoader extends Component {
         if (!entityType) {
             return true
         }
+
+        // in case of error it's a string with the error-message
+        if (typeof currentUser === 'string') {
+            return false
+        }
         const { models } = this.context.d2
         const canCreate = currentUser.canCreate(models[entityType])
         const canDelete = currentUser.canDelete(models[entityType])

--- a/src/components/SectionLoader.js
+++ b/src/components/SectionLoader.js
@@ -107,6 +107,15 @@ class SectionLoader extends Component {
             return <LoadingMask />
         }
 
+        const { routes, sections } = this.routeConfig
+
+        if (sections && sections.length === 0) {
+            const introText = i18n.t(
+                'You do not have authorities to see users, user roles or user groups'
+            )
+            return <ErrorMessage introText={introText} errorMessage="" />
+        }
+
         if (typeof currentUser === 'string') {
             const introText = i18n.t(
                 'There was an error loading the current user'
@@ -117,15 +126,6 @@ class SectionLoader extends Component {
                     errorMessage={currentUser}
                 />
             )
-        }
-
-        const { routes, sections } = this.routeConfig
-
-        if (sections && sections.length === 0) {
-            const introText = i18n.t(
-                'You do not have authorities to see users, user roles or user groups'
-            )
-            return <ErrorMessage introText={introText} errorMessage="" />
         }
 
         return [


### PR DESCRIPTION
Fixes a crash that would occur if the user did not have the `View user`-authority (`F_USER_VIEW`). The app already has a safe-guard for this in the `render()`, but the `userHasAuthorities()` is run in the constructor and in `componentWillReceiveProps()`.