### PR TITLE
feat(user-form): add max org unit level for data output option

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,15 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-08-31T08:08:40.317Z\n"
-"PO-Revision-Date: 2021-08-31T08:08:40.317Z\n"
+"POT-Creation-Date: 2022-02-16T18:07:59.076Z\n"
+"PO-Revision-Date: 2022-02-16T18:07:59.076Z\n"
+
+msgid ""
+"Could not reset user password. Make sure you have the appropriate "
+"permissions."
+msgstr ""
+"Could not reset user password. Make sure you have the appropriate "
+"permissions."
 
 msgid "Use database locale / no translation"
 msgstr "Use database locale / no translation"
@@ -546,6 +553,9 @@ msgstr "Data output and analytic organisation units"
 
 msgid "Search Organisation Units"
 msgstr "Search Organisation Units"
+
+msgid "Maximum organisation unit level for data output"
+msgstr "Maximum organisation unit level for data output"
 
 msgid "Selected user groups"
 msgstr "Selected user groups"

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -171,6 +171,10 @@ class Api {
         )
     }
 
+    getFilledOrganisationUnitLevels() {
+        return this.d2Api.get('filledOrganisationUnitLevels')
+    }
+
     getAttributes(entityType) {
         return this.d2Api
             .get('attributes', {

--- a/src/containers/UserForm/UserForm.js
+++ b/src/containers/UserForm/UserForm.js
@@ -51,6 +51,7 @@ class UserForm extends Component {
         }
         this.trashableAttributesPromise = null
         this.trashableLocalePromise = null
+        this.trashableFilledOrganisationUnitLevelsPromise = null
         this.inviteFields = CONFIG.getInviteFields()
         this.baseFields = CONFIG.getBaseFields()
         this.additionalFields = CONFIG.getAdditionalFields()
@@ -64,10 +65,19 @@ class UserForm extends Component {
             api.getSelectedAndAvailableLocales(username)
         )
         this.trashableAttributesPromise = makeTrashable(api.getAttributes(USER))
+        this.trashableFilledOrganisationUnitLevelsPromise = makeTrashable(
+            api.getFilledOrganisationUnitLevels()
+        )
 
         try {
             const locales = await this.trashableLocalePromise
             const attributes = await this.trashableAttributesPromise
+            const filledOrganisationUnitLevels = (
+                await this.trashableFilledOrganisationUnitLevelsPromise
+            ).map(({ displayName, level }) => ({
+                label: displayName,
+                id: level,
+            }))
             const attributeFields = generateAttributeFields(
                 attributes,
                 user.attributeValues
@@ -76,7 +86,11 @@ class UserForm extends Component {
                 attributeFields,
                 this.props.asyncBlurFields
             )
-            this.setState({ locales, attributeFields })
+            this.setState({
+                locales,
+                attributeFields,
+                filledOrganisationUnitLevels,
+            })
             initialize(
                 userFormInitialValuesSelector(user, locales, attributeFields)
             )
@@ -96,6 +110,7 @@ class UserForm extends Component {
     componentWillUnmount() {
         this.trashableLocalePromise.trash()
         this.trashableAttributesPromise.trash()
+        this.trashableFilledOrganisationUnitLevelsPromise.trash()
     }
 
     toggleShowMore = () => {

--- a/src/containers/UserForm/config.js
+++ b/src/containers/UserForm/config.js
@@ -58,6 +58,8 @@ export const ASSIGNED_ROLES = 'userRoles'
 export const DATA_CAPTURE_AND_MAINTENANCE_ORG_UNITS = 'organisationUnits'
 export const DATA_OUTPUT_AND_ANALYTICS_ORG_UNITS = 'dataViewOrganisationUnits'
 export const TEI_SEARCH_ORG_UNITS = 'teiSearchOrganisationUnits'
+export const DATA_VIEW_MAX_ORGANISATION_UNIT_LEVEL =
+    'dataViewMaxOrganisationUnitLevel'
 export const ASSIGNED_USER_GROUPS = 'userGroups'
 export const DIMENSION_RESTRICTIONS_FOR_DATA_ANALYTICS =
     'catCogsDimensionConstraints'
@@ -81,6 +83,7 @@ export const USER_PROPS = [
     DATA_OUTPUT_AND_ANALYTICS_ORG_UNITS,
     ASSIGNED_USER_GROUPS,
     TEI_SEARCH_ORG_UNITS,
+    DATA_VIEW_MAX_ORGANISATION_UNIT_LEVEL,
 ]
 
 export const USER_CRED_PROPS = [
@@ -292,6 +295,12 @@ export const getAdditionalFields = () => [
         orgUnitType: TEI_SEARCH_ORG_UNITS,
         fieldRenderer: renderSearchableOrgUnitTree,
         wrapperStyle: { ...STYLES.orgUnitTree, paddingRight: '60px' },
+    },
+    {
+        name: DATA_VIEW_MAX_ORGANISATION_UNIT_LEVEL,
+        label: i18n.t('Maximum organisation unit level for data output'),
+        fieldRenderer: renderSelectField,
+        optionsSelector: 'filledOrganisationUnitLevels',
     },
     {
         ...getBaseCaption(),


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-12046

Adds a single select field for setting the max org unit level for data output to the user form. The field is located under the "Search org units" section in the add and edit user screen, i.e. behind the "More options" part. 