### PR TITLE
fix(user): only set email field as required if inviting by email

### DIFF
--- a/src/components/UserForm/BasicInformationSection.js
+++ b/src/components/UserForm/BasicInformationSection.js
@@ -65,7 +65,9 @@ const BasicInformationSection = React.memo(
                     label={i18n.t('Email address')}
                     initialValue={user?.email}
                     validate={
-                        inviteUser ? composeValidators(hasValue, email) : email
+                        inviteUser === 'INVITE_USER'
+                            ? composeValidators(hasValue, email)
+                            : email
                     }
                 />
                 <TextField


### PR DESCRIPTION
Fixes a typo where the email field is always set as required if the server has the capability to invite users.