### PR TITLE
fix(attributes): don't assume presence of values.attributeValues

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -28,7 +28,7 @@ export const groupAttributesQuery = {
 
 export const getAttributeValues = ({ attributes, values }) =>
     attributes.map(attribute => {
-        let value = values.attributeValues[attribute.id]
+        let value = values.attributeValues?.[attribute.id] || ''
         if (attribute.valueType === 'TRUE_ONLY' && !value) {
             value = ''
         }


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/DHIS2-13003

Attribute fields powered by React Final Form are given field names in the format `attributeValues.<attribute ID>` (e.g. `<Field name="attributeValues.oXD88WWSQpR" />`). On form submission, Final Form creates a `values` object containing values for fields that had an `initialValue` prop or were modified.

If no attribute was modified, then the object `values.attributeValues` will not exist and `values.attributeValues[attribute.id]` will throw an error. This PR fixes this issue by using optional chaining.