### PR TITLE
fix: user manager checkbox behaviour

### DIFF
--- a/src/components/BulkMemberManager/BulkMemberManager.js
+++ b/src/components/BulkMemberManager/BulkMemberManager.js
@@ -46,11 +46,14 @@ const BulkMemberManager = ({
         results,
         pager,
         navigateToPage,
+        isPendingChange,
         isSelected,
+        deselect,
         toggleSelected,
         toggleAllSelected,
         clearAllSelected,
     } = useResults({
+        pendingChanges,
         canManageMembers,
         allQuery,
         membersGistQuery,
@@ -87,8 +90,9 @@ const BulkMemberManager = ({
                             mode={mode}
                             filter={filter}
                             onFilterChange={setFilter}
-                            selectedResults={results?.filter(({ id }) =>
-                                isSelected(id)
+                            selectedResults={results?.filter(
+                                ({ id }) =>
+                                    isSelected(id) && !isPendingChange(id)
                             )}
                             pagerTotal={pager?.total}
                             pendingChanges={pendingChanges}
@@ -119,7 +123,7 @@ const BulkMemberManager = ({
                                     ? removeEntity(pendingChanges, entity)
                                     : addEntity(pendingChanges, entity)
                             )
-                            toggleSelected(entity.id)
+                            deselect(entity.id)
                         }}
                         pendingChanges={pendingChanges}
                         onPendingChangeCancel={(entity) => {
@@ -129,6 +133,7 @@ const BulkMemberManager = ({
                                     : cancelAddEntity(pendingChanges, entity)
                             )
                         }}
+                        isPendingChange={isPendingChange}
                         isSelected={isSelected}
                         onToggleSelected={toggleSelected}
                         onToggleAllSelected={() =>

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
@@ -62,24 +62,9 @@ const ResultsTable = ({
         )
     }
 
-    const { noneSelected, allSelected, allPending } = results.reduce(
-        (state, { id }) => {
-            if (isSelected(id)) {
-                state.noneSelected = false
-            } else {
-                state.allSelected = false
-            }
-            if (!isPendingChange(id)) {
-                state.allPending = false
-            }
-            return state
-        },
-        {
-            noneSelected: true,
-            allSelected: true,
-            allPending: true,
-        }
-    )
+    const noneSelected =  results.every(({ id }) => !isSelected(id))
+    const allSelected =  results.every(({ id }) => isSelected(id))
+    const allPending = results.every(({ id }) => isPendingChange(id))
 
     return (
         <DataTable>

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
@@ -62,8 +62,8 @@ const ResultsTable = ({
         )
     }
 
-    const noneSelected =  results.every(({ id }) => !isSelected(id))
-    const allSelected =  results.every(({ id }) => isSelected(id))
+    const noneSelected = results.every(({ id }) => !isSelected(id))
+    const allSelected = results.every(({ id }) => isSelected(id))
     const allPending = results.every(({ id }) => isPendingChange(id))
 
     return (

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTable.js
@@ -29,6 +29,7 @@ const ResultsTable = ({
     onActionClick,
     pendingChanges,
     onPendingChangeCancel,
+    isPendingChange,
     isSelected,
     onToggleSelected,
     onToggleAllSelected,
@@ -61,7 +62,24 @@ const ResultsTable = ({
         )
     }
 
-    const selectedResults = results.filter(({ id }) => isSelected(id))
+    const { noneSelected, allSelected, allPending } = results.reduce(
+        (state, { id }) => {
+            if (isSelected(id)) {
+                state.noneSelected = false
+            } else {
+                state.allSelected = false
+            }
+            if (!isPendingChange(id)) {
+                state.allPending = false
+            }
+            return state
+        },
+        {
+            noneSelected: true,
+            allSelected: true,
+            allPending: true,
+        }
+    )
 
     return (
         <DataTable>
@@ -69,13 +87,10 @@ const ResultsTable = ({
                 <DataTableRow>
                     <DataTableColumnHeader width="48px">
                         <Checkbox
-                            checked={selectedResults.length === results.length}
-                            indeterminate={
-                                selectedResults.length > 0 &&
-                                selectedResults.length < results.length
-                            }
+                            checked={allSelected || allPending}
+                            indeterminate={!noneSelected && !allSelected}
+                            disabled={allPending}
                             onChange={() => onToggleAllSelected(pendingChanges)}
-                            disabled={loading}
                         />
                     </DataTableColumnHeader>
                     {columns.map((column) => (
@@ -124,7 +139,10 @@ const ResultsTable = ({
                             onPendingChangeCancel={() =>
                                 onPendingChangeCancel(pendingChangeEntity)
                             }
-                            selected={isSelected(result.id)}
+                            selected={
+                                isSelected(result.id) ||
+                                isPendingChange(result.id)
+                            }
                             onToggleSelected={() => onToggleSelected(result.id)}
                         />
                     )
@@ -142,6 +160,7 @@ ResultsTable.propTypes = {
             mapDataToValue: PropTypes.func.isRequired,
         })
     ).isRequired,
+    isPendingChange: PropTypes.func.isRequired,
     isSelected: PropTypes.func.isRequired,
     loading: PropTypes.bool.isRequired,
     mode: PropTypes.oneOf(['MEMBERS', 'NON_MEMBERS']).isRequired,

--- a/src/components/BulkMemberManager/hooks/useResults/useResults.js
+++ b/src/components/BulkMemberManager/hooks/useResults/useResults.js
@@ -1,5 +1,5 @@
 import { useDataQuery } from '@dhis2/app-runtime'
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useDebounce } from 'use-debounce'
 import { useSet } from './useSet.js'
 
@@ -12,13 +12,11 @@ export const useResults = ({
     filterDebounceMs,
     mode,
 }) => {
-    const pendingChangesForMode = useMemo(() => {
-        const currentPendingChanges =
-            mode === 'MEMBERS'
-                ? pendingChanges.removals
-                : pendingChanges.additions
-        return new Set(currentPendingChanges.map(({ id }) => id))
-    }, [mode, pendingChanges])
+    const currentPendingChanges =
+        mode === 'MEMBERS' ? pendingChanges.removals : pendingChanges.additions
+    const pendingChangesForMode = new Set(
+        currentPendingChanges.map(({ id }) => id)
+    )
     const prevPageRef = useRef({
         members: {
             pager: undefined,


### PR DESCRIPTION
Fixes [DHIS2-13914](https://dhis2.atlassian.net/browse/DHIS2-13914)

What I've addressed here is the following:
- It was possible to end up with duplicate items in the list on the right
- The button to bulk add items to the list to the right was sometimes visible when it shouldn't have been
- The toggle-all-checkbox would sometimes not have the correct selection/disabled state

All of the above was related to the fact that "selected results" and "pending changes" are separate things and should be handled differently, depending on the context.

@cooper-joe could you review the current implementation?