### PR TITLE
fix: address various style and text issues

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-11-16T12:36:05.591Z\n"
-"PO-Revision-Date: 2022-11-16T12:36:05.591Z\n"
+"POT-Creation-Date: 2022-11-17T13:40:24.697Z\n"
+"PO-Revision-Date: 2022-11-17T13:40:24.697Z\n"
 
 msgid "Yes"
 msgstr "Yes"
@@ -607,6 +607,12 @@ msgstr "LDAP identifier"
 msgid "External authentication only (OpenID / LDAP)"
 msgstr "External authentication only (OpenID / LDAP)"
 
+msgid "Send invite"
+msgstr "Send invite"
+
+msgid "Cancel invite"
+msgstr "Cancel invite"
+
 msgid "Invalid username"
 msgstr "Invalid username"
 
@@ -905,11 +911,8 @@ msgstr "Password of user \"{{- name}}\" reset successfuly"
 msgid "There was an error resetting the password: {{- error}}"
 msgstr "There was an error resetting the password: {{- error}}"
 
-msgid "Reset password of user {{- name}}"
-msgstr "Reset password of user {{- name}}"
-
-msgid "Are you sure you want to reset {{- name}}'s password?"
-msgstr "Are you sure you want to reset {{- name}}'s password?"
+msgid "Are you sure you want to reset the password for {{- name}}?"
+msgstr "Are you sure you want to reset the password for {{- name}}?"
 
 msgid "Yes, reset"
 msgstr "Yes, reset"
@@ -947,11 +950,14 @@ msgstr "User Management"
 msgid "Last login"
 msgstr "Last login"
 
-msgid "Account disabled?"
-msgstr "Account disabled?"
+msgid "Status"
+msgstr "Status"
 
 msgid "Disabled"
 msgstr "Disabled"
+
+msgid "Active"
+msgstr "Active"
 
 msgid "Male"
 msgstr "Male"

--- a/src/components/BulkMemberManager/BulkMemberManager.module.css
+++ b/src/components/BulkMemberManager/BulkMemberManager.module.css
@@ -4,7 +4,7 @@
 
 .grid {
     display: grid;
-    max-width: 900px;
+    max-width: 1800px;
     grid-template-columns: 2fr 1fr;
     gap: var(--spacers-dp8);
     margin-top: var(--spacers-dp12);

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.js
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.js
@@ -8,18 +8,10 @@ import {
     IconCross16,
     colors,
 } from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './ResultsTableRow.module.css'
-
-const getRowClass = (pendingChangeAction) => {
-    switch (pendingChangeAction) {
-        case 'ADD':
-            return styles.pendingAddRow
-        case 'REMOVE':
-            return styles.pendingRemoveRow
-    }
-}
 
 const PendingChange = ({ action, onCancel }) => (
     <div className={styles.pendingChange}>
@@ -57,7 +49,12 @@ const ResultsTableRow = ({
     selected,
     onToggleSelected,
 }) => (
-    <DataTableRow className={getRowClass(pendingChangeAction)}>
+    <DataTableRow
+        className={cx(styles.row, {
+            [styles.pendingAddRow]: pendingChangeAction === 'ADD',
+            [styles.pendingRemoveRow]: pendingChangeAction === 'REMOVE',
+        })}
+    >
         <DataTableCell width="48px">
             <Checkbox
                 checked={selected}
@@ -68,7 +65,7 @@ const ResultsTableRow = ({
         {cells.map((cell, index) => (
             <DataTableCell key={index}>{cell}</DataTableCell>
         ))}
-        <DataTableCell>
+        <DataTableCell className={styles.actionCell}>
             {pendingChangeAction ? (
                 <PendingChange
                     action={pendingChangeAction}

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.module.css
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.module.css
@@ -23,3 +23,7 @@
 .pendingRemoveRow .pendingChangeDescription {
     color: var(--colors-red700);
 }
+
+tr.row td.actionCell {
+    width: 320px;
+}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -281,7 +281,14 @@ TransferField.propTypes = {
     required: PropTypes.bool,
 }
 
-const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
+const Form = ({
+    loading,
+    error,
+    children,
+    submitButtonLabel,
+    cancelButtonLabel,
+    onSubmit,
+}) => {
     const history = useHistory()
     const handleCancel = () => history.goBack()
 
@@ -331,7 +338,7 @@ const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
                             {submitButtonLabel}
                         </Button>
                         <Button onClick={handleCancel} disabled={submitting}>
-                            {i18n.t('Cancel without saving')}
+                            {cancelButtonLabel}
                         </Button>
                     </ButtonStrip>
                 </form>
@@ -340,10 +347,15 @@ const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
     )
 }
 
+Form.defaultProps = {
+    cancelButtonLabel: i18n.t('Cancel without saving'),
+}
+
 Form.propTypes = {
     children: PropTypes.func.isRequired,
     submitButtonLabel: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    cancelButtonLabel: PropTypes.string,
     error: PropTypes.instanceOf(Error),
     loading: PropTypes.bool,
 }

--- a/src/components/UserForm/InviteUserSection.js
+++ b/src/components/UserForm/InviteUserSection.js
@@ -1,9 +1,18 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useField } from 'react-final-form'
 import { FormSection, SingleSelectField } from '../Form.js'
 
-const InviteUserSection = ({ user, emailConfigured }) => {
+const InviteUserSection = ({ user, emailConfigured, setIsInvite }) => {
+    const {
+        input: { value },
+    } = useField('inviteUser', { subscription: { value: true, data: true } })
+
+    useEffect(() => {
+        setIsInvite(value === 'INVITE_USER')
+    }, [value])
+
     if (user || !emailConfigured) {
         return null
     }
@@ -31,6 +40,7 @@ const InviteUserSection = ({ user, emailConfigured }) => {
 
 InviteUserSection.propTypes = {
     emailConfigured: PropTypes.bool,
+    setIsInvite: PropTypes.func,
     user: PropTypes.object,
 }
 

--- a/src/components/UserForm/InviteUserSection.js
+++ b/src/components/UserForm/InviteUserSection.js
@@ -7,11 +7,11 @@ import { FormSection, SingleSelectField } from '../Form.js'
 const InviteUserSection = ({ user, emailConfigured, setIsInvite }) => {
     const {
         input: { value },
-    } = useField('inviteUser', { subscription: { value: true, data: true } })
+    } = useField('inviteUser', { subscription: { value: true } })
 
     useEffect(() => {
         setIsInvite(value === 'INVITE_USER')
-    }, [value])
+    }, [value, setIsInvite])
 
     if (user || !emailConfigured) {
         return null

--- a/src/components/UserForm/UserForm.js
+++ b/src/components/UserForm/UserForm.js
@@ -20,18 +20,6 @@ import SecuritySection from './SecuritySection.js'
 import { useFormData } from './useFormData.js'
 import styles from './UserForm.module.css'
 
-const getFormButtonTexts = (submitButtonLabel, mode) =>
-    mode === 'INVITE_USER'
-        ? {
-              mode,
-              submit: i18n.t('Send invite'),
-              cancel: i18n.t('Cancel invite'),
-          }
-        : {
-              mode,
-              submit: submitButtonLabel,
-          }
-
 const UserForm = ({
     submitButtonLabel,
     user,
@@ -41,9 +29,7 @@ const UserForm = ({
     const {
         systemInfo: { emailConfigured },
     } = useConfig()
-    const [formButtonTexts, setFormButtonTexts] = useState(
-        getFormButtonTexts(submitButtonLabel)
-    )
+    const [isInvite, setIsInvite] = useState(false)
     const history = useHistory()
     const engine = useDataEngine()
     const {
@@ -156,8 +142,14 @@ const UserForm = ({
         <Form
             loading={loading}
             error={error}
-            submitButtonLabel={formButtonTexts.submit}
-            cancelButtonLabel={formButtonTexts.cancel}
+            submitButtonLabel={
+                isInvite ? i18n.t('Send invite') : submitButtonLabel
+            }
+            cancelButtonLabel={
+                isInvite
+                    ? i18n.t('Cancel invite')
+                    : i18n.t('Cancel without saving')
+            }
             onSubmit={handleSubmit}
         >
             {({ values, submitError }) => (
@@ -178,6 +170,7 @@ const UserForm = ({
                     <InviteUserSection
                         user={user}
                         emailConfigured={emailConfigured}
+                        setIsInvite={setIsInvite}
                     />
                     <BasicInformationSection
                         user={user}

--- a/src/components/UserForm/UserForm.js
+++ b/src/components/UserForm/UserForm.js
@@ -1,6 +1,6 @@
 import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { NoticeBox, FinalForm, ReactFinalForm } from '@dhis2/ui'
+import { NoticeBox, FinalForm } from '@dhis2/ui'
 import { keyBy } from 'lodash-es'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
@@ -214,27 +214,6 @@ const UserForm = ({
                             />
                         </FormSection>
                     )}
-                    <ReactFinalForm.FormSpy
-                        subscription={{
-                            values: true,
-                            active: true,
-                            modified: true,
-                        }}
-                        onChange={({ active, modified, values }) => {
-                            if (
-                                active === 'inviteUser' &&
-                                modified.inviteUser &&
-                                values.inviteUser !== formButtonTexts.mode
-                            ) {
-                                setFormButtonTexts(
-                                    getFormButtonTexts(
-                                        submitButtonLabel,
-                                        values.inviteUser
-                                    )
-                                )
-                            }
-                        }}
-                    />
                 </>
             )}
         </Form>

--- a/src/components/UserForm/UserForm.js
+++ b/src/components/UserForm/UserForm.js
@@ -1,9 +1,9 @@
 import { useConfig, useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { NoticeBox, FinalForm } from '@dhis2/ui'
+import { NoticeBox, FinalForm, ReactFinalForm } from '@dhis2/ui'
 import { keyBy } from 'lodash-es'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import { useCurrentUser } from '../../hooks/useCurrentUser.js'
 import Attributes from '../Attributes/index.js'
@@ -20,6 +20,18 @@ import SecuritySection from './SecuritySection.js'
 import { useFormData } from './useFormData.js'
 import styles from './UserForm.module.css'
 
+const getFormButtonTexts = (submitButtonLabel, mode) =>
+    mode === 'INVITE_USER'
+        ? {
+              mode,
+              submit: i18n.t('Send invite'),
+              cancel: i18n.t('Cancel invite'),
+          }
+        : {
+              mode,
+              submit: submitButtonLabel,
+          }
+
 const UserForm = ({
     submitButtonLabel,
     user,
@@ -29,6 +41,9 @@ const UserForm = ({
     const {
         systemInfo: { emailConfigured },
     } = useConfig()
+    const [formButtonTexts, setFormButtonTexts] = useState(
+        getFormButtonTexts(submitButtonLabel)
+    )
     const history = useHistory()
     const engine = useDataEngine()
     const {
@@ -141,7 +156,8 @@ const UserForm = ({
         <Form
             loading={loading}
             error={error}
-            submitButtonLabel={submitButtonLabel}
+            submitButtonLabel={formButtonTexts.submit}
+            cancelButtonLabel={formButtonTexts.cancel}
             onSubmit={handleSubmit}
         >
             {({ values, submitError }) => (
@@ -205,6 +221,27 @@ const UserForm = ({
                             />
                         </FormSection>
                     )}
+                    <ReactFinalForm.FormSpy
+                        subscription={{
+                            values: true,
+                            active: true,
+                            modified: true,
+                        }}
+                        onChange={({ active, modified, values }) => {
+                            if (
+                                active === 'inviteUser' &&
+                                modified.inviteUser &&
+                                values.inviteUser !== formButtonTexts.mode
+                            ) {
+                                setFormButtonTexts(
+                                    getFormButtonTexts(
+                                        submitButtonLabel,
+                                        values.inviteUser
+                                    )
+                                )
+                            }
+                        }}
+                    />
                 </>
             )}
         </Form>

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -50,13 +50,20 @@ const ContextMenu = ({ user, anchorRef, refetchUsers, onClose }) => {
         userCredentials: { disabled, twoFA },
     } = user
     const canReplicate =
-        access.update && currentUser.authorities.includes('F_REPLICATE_USER')
+        access.update &&
+        currentUser.authorities.some(
+            (auth) => auth === 'ALL' || auth === 'F_REPLICATE_USER'
+        )
     const canResetPassword =
         emailConfigured &&
         user.email &&
         access.update &&
-        (currentUser.authorities.includes('F_USER_ADD') ||
-            currentUser.authorities.includes('F_USER_ADD_WITHIN_MANAGED_GROUP'))
+        currentUser.authorities.some(
+            (auth) =>
+                auth === 'ALL' ||
+                auth === 'F_USER_ADD' ||
+                auth === 'F_USER_ADD_WITHIN_MANAGED_GROUP'
+        )
     const canDisable = currentUser.id !== user.id && access.update && !disabled
     const canDelete = currentUser.id !== user.id && access.delete
 

--- a/src/pages/UserList/ContextMenu/Modals/ResetPasswordModal.js
+++ b/src/pages/UserList/ContextMenu/Modals/ResetPasswordModal.js
@@ -47,14 +47,10 @@ const ResetPasswordModal = ({ user, onClose }) => {
 
     return (
         <Modal small>
-            <ModalTitle>
-                {i18n.t('Reset password of user {{- name}}', {
-                    name: user.displayName,
-                })}
-            </ModalTitle>
+            <ModalTitle>{i18n.t('Reset password')}</ModalTitle>
             <ModalContent>
                 {i18n.t(
-                    `Are you sure you want to reset {{- name}}'s password?`,
+                    `Are you sure you want to reset the password for {{- name}}?`,
                     { name: user.displayName }
                 )}
             </ModalContent>

--- a/src/pages/UserList/UserTable.js
+++ b/src/pages/UserList/UserTable.js
@@ -70,7 +70,7 @@ const UserTable = ({
                         {i18n.t('Last login')}
                     </DataTableColumnHeader>
                     <DataTableColumnHeader>
-                        {i18n.t('Account disabled?')}
+                        {i18n.t('Status')}
                     </DataTableColumnHeader>
                     <DataTableColumnHeader>
                         {i18n.t('Actions')}
@@ -105,7 +105,9 @@ const UserTable = ({
                                 )}
                             </DataTableCell>
                             <DataTableCell onClick={handleClick}>
-                                {disabled && i18n.t('Disabled')}
+                                {disabled
+                                    ? i18n.t('Disabled')
+                                    : i18n.t('Active')}
                             </DataTableCell>
                             <DataTableCell>
                                 <ContextMenuButton

--- a/src/pages/UserList/UserTable.test.js
+++ b/src/pages/UserList/UserTable.test.js
@@ -109,7 +109,7 @@ describe('<UserTable>', () => {
             screen.getByRole('columnheader', { name: 'Last login' })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('columnheader', { name: 'Account disabled?' })
+            screen.getByRole('columnheader', { name: 'Status' })
         ).toBeInTheDocument()
         expect(
             screen.getByRole('columnheader', { name: 'Actions' })


### PR DESCRIPTION
Fixes:
- [DHIS2-13425](https://dhis2.atlassian.net/browse/DHIS2-13425): Renamed the user table column from ""Account disabled?" to "status" and now populating each row with "Active" or "Disabled" text.
- [DHIS2-12910](https://dhis2.atlassian.net/browse/DHIS2-12910): Changed the button texts below the "create user form" when inviting a user by email*.
- [DHIS2-13424](https://dhis2.atlassian.net/browse/DHIS2-13424): Tweaked the texts in the reset password dialog - this dialog can be opened via the context menu in the user table *.
- [DHIS2-14064](https://dhis2.atlassian.net/browse/DHIS2-14064): Gave the bulk user manager - in the create/edit user-group form - some more width, but still kept a max-width with very wide monitors in mind. I also added some extra whitespace to the last column to prevent the content from jumping around too much. There is some extra space there, but possibly in languages that use a lot of characters there might still be a content jump. I didn't want to add too much whitespace, because it could have a negative impact on the readability of the username on narrow screens.

[*] A note for DHIS2-12910 and DHIS2-13424: These issues can only be tested fully by QA if an email server is configured for the system and the user has the required authorities. Developers reviewing this PR are advised to check out this branch locally and running the app. I will add a few instructions:
1. Just change the code below to `emailConfigured={true}` to test DHIS2-12910:
    https://github.com/dhis2/user-app/blob/4fdf8fdf41db5059d55275914154d61acd9fd76f/src/components/UserForm/UserForm.js#L180
1. Just render this unconditionally to see the button in the user-table context-menu that shows the reset-password dialog, to test DHIS2-13424:
https://github.com/dhis2/user-app/blob/4fdf8fdf41db5059d55275914154d61acd9fd76f/src/pages/UserList/ContextMenu/ContextMenu.js#L101-L110
