### PR TITLE
fix: use dedicated endpoint for checking the username

### DIFF
--- a/src/components/UserForm/validators.js
+++ b/src/components/UserForm/validators.js
@@ -8,19 +8,14 @@ export const useDebouncedUniqueUsernameValidator = ({
     username: currentUsername,
 }) => {
     const engine = useDataEngine()
-    const findUserByUsername = pDebounce(async (username) => {
-        const {
-            users: { users },
-        } = await engine.query({
-            users: {
-                resource: 'users',
-                params: {
-                    filter: `userCredentials.username:eq:${username}`,
-                    fields: 'id',
-                },
+    const checkUsername = pDebounce(async (username) => {
+        const { result } = await engine.query({
+            result: {
+                resource: 'account/username',
+                params: { username },
             },
         })
-        return users[0]
+        return result
     }, 350)
     const validator = async (username) => {
         if (username === currentUsername) {
@@ -28,8 +23,8 @@ export const useDebouncedUniqueUsernameValidator = ({
         }
 
         try {
-            const user = await findUserByUsername(username)
-            if (user) {
+            const { response } = await checkUsername(username)
+            if (response === 'error') {
                 return i18n.t('Username already taken')
             }
         } catch (error) {
@@ -46,7 +41,6 @@ export const useUserNameValidator = ({ user, isInviteUser }) => {
         useDebouncedUniqueUsernameValidator({
             username: user?.userCredentials.username,
         })
-
     if (user) {
         return undefined
     }

--- a/src/pages/UserList/ContextMenu/Modals/ReplicateModal.js
+++ b/src/pages/UserList/ContextMenu/Modals/ReplicateModal.js
@@ -9,16 +9,23 @@ import {
     Button,
     ReactFinalForm,
     InputFieldFF,
-    dhis2Username,
     dhis2Password,
+    composeValidators,
+    hasValue,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { TextField } from '../../../../components/Form.js'
+import { useUserNameValidator } from '../../../../components/UserForm/validators.js'
 import { useFetchAlert } from '../../../../hooks/useFetchAlert.js'
 import styles from './ReplicateModal.module.css'
 
 const ReplicateModal = ({ user, refetchUsers, onClose }) => {
     const engine = useDataEngine()
+    const validateUserName = useUserNameValidator({
+        user: undefined,
+        isInviteUser: false,
+    })
     const { showSuccess, showError } = useFetchAlert()
 
     const handleReplicate = async ({ username, password }) => {
@@ -57,16 +64,16 @@ const ReplicateModal = ({ user, refetchUsers, onClose }) => {
                     </ModalTitle>
                     <ModalContent>
                         <form onSubmit={handleSubmit}>
-                            <ReactFinalForm.Field
+                            <TextField
                                 name="username"
                                 label={i18n.t('Username')}
                                 placeholder={i18n.t('Username for new user')}
-                                validate={dhis2Username}
+                                validate={validateUserName}
                                 autoComplete="new-password"
                                 className={styles.field}
                                 component={InputFieldFF}
                             />
-                            <ReactFinalForm.Field
+                            <TextField
                                 name="password"
                                 label={i18n.t('Password')}
                                 type="password"
@@ -74,7 +81,10 @@ const ReplicateModal = ({ user, refetchUsers, onClose }) => {
                                 helpText={i18n.t(
                                     'Password should be at least 8 characters long, with at least one lowercase character, one uppercase character and one special character.'
                                 )}
-                                validate={dhis2Password}
+                                validate={composeValidators(
+                                    hasValue,
+                                    dhis2Password
+                                )}
                                 autoComplete="new-password"
                                 className={styles.field}
                                 component={InputFieldFF}

--- a/src/pages/UserList/UserTable.test.js
+++ b/src/pages/UserList/UserTable.test.js
@@ -4,6 +4,23 @@ import moment from 'moment'
 import React from 'react'
 import UserTable from './UserTable.js'
 
+/*
+ * Since we don't need to verify if this debounce module
+ * works as expected it is OK to mock it. The fact that
+ * I mocked it is because without the mock, the test suite will
+ * fail due to a Jest file parse error. This error started
+ * to appear after adding an import of `useUserNameValidator`
+ * to `src/pages/UserList/ContextMenu/Modals/ReplicateModal.js`
+ * in the commit below:
+ * https://github.com/dhis2/user-app/pull/1092/commits/c4edd10011e73e327cf6f1cc26b5c51e342c4081
+ * I couldn't identify the root cause of this and settled on this
+ * workaround in the end...
+ */
+jest.mock('p-debounce', () => ({
+    __esModule: true,
+    default: (fn) => fn,
+}))
+
 describe('<UserTable>', () => {
     it('renders a loading spinner while users are being fetched', () => {
         render(


### PR DESCRIPTION
Fixes [DHIS2-14147](https://dhis2.atlassian.net/browse/DHIS2-14147)

Whilst migrating the username check to the new endpoint, I realised the username uniqueness check in the replicate user dialog had been removed during a previous refactor. Once I had added that validator I realised the loading state was not showing while the async validation was running, so I also updated the input components there....