### PR TITLE
fix: add first name validator (v37) [DHIS2-14793]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-16T18:07:59.076Z\n"
-"PO-Revision-Date: 2022-02-16T18:07:59.076Z\n"
+"POT-Creation-Date: 2023-03-03T10:52:57.388Z\n"
+"PO-Revision-Date: 2023-03-03T10:52:57.388Z\n"
 
 msgid ""
 "Could not reset user password. Make sure you have the appropriate "
@@ -684,6 +684,12 @@ msgstr "A username should be at least 2 characters long"
 
 msgid "Username may not exceed 140 characters"
 msgstr "Username may not exceed 140 characters"
+
+msgid "First name should be at least 2 characters long"
+msgstr "First name should be at least 2 characters long"
+
+msgid "First name may not exceed 160 characters"
+msgstr "First name may not exceed 160 characters"
 
 msgid "Please provide a valid international phone number (+0123456789)"
 msgstr "Please provide a valid international phone number (+0123456789)"

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -93,6 +93,16 @@ export function username(value) {
     }
 }
 
+export function firstName(value) {
+    if (hasValue(value) && value.length < 2) {
+        return i18n.t('First name should be at least 2 characters long')
+    }
+
+    if (hasValue(value) && value.length > 160) {
+        return i18n.t('First name may not exceed 160 characters')
+    }
+}
+
 export function whatsApp(value) {
     if (hasValue(value) && !INTERNATIONAL_PHONE_NUMBER_PATTERN.test(value)) {
         return i18n.t(


### PR DESCRIPTION
Addresses this [DHIS2-14793](https://dhis2.atlassian.net/browse/DHIS2-14793) (from a CoP post)

**After**
<img width="519" alt="image" src="https://user-images.githubusercontent.com/18490902/222703372-ee2826fc-9f4c-4d48-a6d3-89e10a9da4b2.png">


Note: the modern version of the users app also lacks a validator for first name, but upon attempting to save, the error will be displayed on the field. We could update this as well (but it's not requested directly by the ticket)

[DHIS2-14793]: https://dhis2.atlassian.net/browse/DHIS2-14793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ