### PR TITLE
fix: add surname validator (v37) [DHIS2-14793]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-03-03T10:52:57.388Z\n"
-"PO-Revision-Date: 2023-03-03T10:52:57.388Z\n"
+"POT-Creation-Date: 2023-03-06T12:01:39.768Z\n"
+"PO-Revision-Date: 2023-03-06T12:01:39.768Z\n"
 
 msgid ""
 "Could not reset user password. Make sure you have the appropriate "
@@ -684,6 +684,12 @@ msgstr "A username should be at least 2 characters long"
 
 msgid "Username may not exceed 140 characters"
 msgstr "Username may not exceed 140 characters"
+
+msgid "Surname should be at least 2 characters long"
+msgstr "Surname should be at least 2 characters long"
+
+msgid "Surname may not exceed 160 characters"
+msgstr "Surname may not exceed 160 characters"
 
 msgid "First name should be at least 2 characters long"
 msgstr "First name should be at least 2 characters long"

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -93,6 +93,16 @@ export function username(value) {
     }
 }
 
+export function surname(value) {
+    if (hasValue(value) && value.length < 2) {
+        return i18n.t('Surname should be at least 2 characters long')
+    }
+
+    if (hasValue(value) && value.length > 160) {
+        return i18n.t('Surname may not exceed 160 characters')
+    }
+}
+
 export function firstName(value) {
     if (hasValue(value) && value.length < 2) {
         return i18n.t('First name should be at least 2 characters long')


### PR DESCRIPTION
Sorry; I did not read the [ticket](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-14793) close enough. While the original CoP post was about adding a validator on the first name, Gassim pointed out on the ticket that this also applies for surname, so we should add a validator there too.

**Before**
<img width="610" alt="image" src="https://user-images.githubusercontent.com/18490902/223106301-205231a5-a832-4d0b-9826-af9291ed0b37.png">

**After**
<img width="489" alt="image" src="https://user-images.githubusercontent.com/18490902/223106092-67f41277-5633-4c59-adc6-e37af2efea3e.png">
