### PR TITLE
fix: move dimension constraints [DHIS2-14870]

### DIFF
--- a/src/components/UserForm/getUserData.js
+++ b/src/components/UserForm/getUserData.js
@@ -69,12 +69,6 @@ export const getUserData = ({
             ldapId,
             externalAuth,
             userRoles: wrapIds(userRoles),
-            // Dimension constraints are combined into a single input
-            // component, but need to be stored separately
-            catDimensionConstraints: constraintsForType('CATEGORY'),
-            cogsDimensionConstraints: constraintsForType(
-                'CATEGORY_OPTION_GROUP_SET'
-            ),
         },
 
         email,
@@ -93,6 +87,12 @@ export const getUserData = ({
             dataViewMaxOrganisationUnitLevel ??
             Number(dataViewMaxOrganisationUnitLevel),
         userGroups: wrapIds(userGroups),
+        // Dimension constraints are combined into a single input
+        // component, but need to be stored separately
+        catDimensionConstraints: constraintsForType('CATEGORY'),
+        cogsDimensionConstraints: constraintsForType(
+            'CATEGORY_OPTION_GROUP_SET'
+        ),
 
         attributeValues: getAttributeValues({ attributes, values }),
     }


### PR DESCRIPTION
This fixes the issue in the app by putting the updated `catDimensionConstraints` and `cogsDimensionConstraints` on the main payload (rather than as properties on `userCredentials`)

but need to confirm with backend team if this is the desired approach