### PR TITLE
fix: handle empty user roles response [DHIS2-15368]

### DIFF
--- a/src/components/UserForm/RolesSection.js
+++ b/src/components/UserForm/RolesSection.js
@@ -19,7 +19,7 @@ const RolesSection = React.memo(
                 rightHeader={i18n.t('User roles this user is assigned')}
                 options={userRoleOptions}
                 initialValue={
-                    user?.userCredentials.userRoles.map(({ id }) => id) || []
+                    user?.userCredentials?.userRoles?.map(({ id }) => id) || []
                 }
                 validate={hasSelectionValidator}
             />


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15368

Front end expects response from api/user/{uid} to contain an object `userCredentials` which contains an array `userRoles`. However, when there are no `userRoles`, `userCredentials` does not contain the property `userRoles`, and hence causes the app to crash (tries to map non-existent `userRoles` array)

This arguably might be something the backend should change, but updating the front-end also is sufficient for the immediate purpose of stopping the app from crashing.

Note: we decided in our meeting on 20 June that we would fix this on the front end and backend team will evaluate if they also want to do anything here.