### PR TITLE
fix: hide reset password [DHIS2-15354]

### DIFF
--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -1,3 +1,4 @@
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import {
     Layer,
@@ -45,6 +46,9 @@ const ContextMenu = ({
     refetchUsers,
     onClose,
 }) => {
+    const {
+        systemInfo: { emailConfigured },
+    } = useConfig()
     const [CurrentModal, setCurrentModal] = useCurrentModal()
     const {
         access,
@@ -53,6 +57,8 @@ const ContextMenu = ({
     const canReplicate =
         access.update && currentUser.authorities.has('F_REPLICATE_USER')
     const canResetPassword =
+        emailConfigured &&
+        user.email &&
         access.update &&
         (currentUser.authorities.has('F_USER_ADD') ||
             currentUser.authorities.has('F_USER_ADD_WITHIN_MANAGED_GROUP'))
@@ -171,6 +177,7 @@ ContextMenu.propTypes = {
             disabled: PropTypes.bool.isRequired,
             twoFA: PropTypes.bool.isRequired,
         }).isRequired,
+        email: PropTypes.string,
     }).isRequired,
     onClose: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-15354.

This issue was fixed in versions 39+ by this PR: https://github.com/dhis2/user-app/pull/924. This PR effectively backports that change to v38.

(Note in before "Reset password" option is displayed for https://debug.dhis2.org/2.38, whereas it's hidden in after. It should be hidden because email is not configured for this instance)

**Before**
<img width="1223" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/bad28e79-df82-4d69-b45e-33a4c24fbd9f">


**After**
<img width="1229" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/df769a3a-c726-461f-aac5-0432d1dda81f">

