### PR TITLE
fix: org unit search logic [DHIS2-14585]

### DIFF
--- a/src/components/SearchableOrgUnitTree/AsyncAutoComplete/useOrgUnitSearchResults.js
+++ b/src/components/SearchableOrgUnitTree/AsyncAutoComplete/useOrgUnitSearchResults.js
@@ -16,7 +16,7 @@ const query = {
                 'children::isNotEmpty',
                 'ancestors',
             ],
-            filter: `name:$ilike:${searchText}`,
+            filter: `displayName:ilike:${searchText}`,
             paging: true,
             pageSize: PAGE_SIZE,
         }),


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-14585

We have a typo in an apparent typo in our org unit filter logic in the user app that is prevent matches not at the beginning of the string to match.

In addition, I saw that we were looking for matches on `name`, whereas we should use `displayName` (i.e. to match based on the user's currently selected UI locale)

**Before**
<img width="526" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/4c45fb22-dbf9-4f64-9f2c-e15c0f1ec4cb">


**After**
<img width="552" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/2cb62e3b-af1c-4deb-b05a-f767bfd3ca75">
