### PR TITLE
fix: account expiry clear

### DIFF
--- a/src/components/UserForm/getUserData.js
+++ b/src/components/UserForm/getUserData.js
@@ -43,6 +43,12 @@ export const getUserData = ({
             )
         )
 
+    // See https://jira.dhis2.org/browse/DHIS2-10569
+    const updatedAccountExpiry =
+        typeof accountExpiry === 'string' && accountExpiry !== ''
+            ? accountExpiry
+            : undefined
+
     return {
         // Because the data object is used as the payload of a PUT request,
         // properties that are omitted will be removed. To prevent this, all
@@ -60,11 +66,7 @@ export const getUserData = ({
                 !inviteUser && !externalAuth && (!user || changePassword)
                     ? password
                     : undefined,
-            // See https://jira.dhis2.org/browse/DHIS2-10569
-            accountExpiry:
-                typeof accountExpiry === 'string' && accountExpiry !== ''
-                    ? accountExpiry
-                    : undefined,
+            accountExpiry: updatedAccountExpiry,
             openId,
             ldapId,
             externalAuth,
@@ -77,6 +79,7 @@ export const getUserData = ({
             ),
         },
 
+        accountExpiry: updatedAccountExpiry,
         email,
         firstName,
         surname,


### PR DESCRIPTION
See [DHIS2-15359](https://dhis2.atlassian.net/browse/DHIS2-15359). Currently we update accountExpiry in useCredentials but it's also a property on the main payload. Since it occurs in both places (but is inconsistent), it does not get cleared out when it is removed. Morten Svænes looked at this on the backend and thought we could either update in both places or refactor to use PATCH. I'm just updating in both parts of the payload as I think that is simpler for just a bug fix.

**Before**
![expiry_user_current](https://github.com/dhis2/user-app/assets/18490902/ea68ad54-aed6-4615-8a80-8484c13f5cd9)


**After**
![expiry_user_after](https://github.com/dhis2/user-app/assets/18490902/c93a873d-0115-49b9-bdc6-177dd0a9f685)


[DHIS2-15359]: https://dhis2.atlassian.net/browse/DHIS2-15359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ