### PR TITLE
fix: catch up fixes v39 [DHIS2-15524]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -595,6 +595,12 @@ msgstr "LDAP identifier"
 msgid "External authentication only (OpenID / LDAP)"
 msgstr "External authentication only (OpenID / LDAP)"
 
+msgid "Send invite"
+msgstr "Send invite"
+
+msgid "Cancel invite"
+msgstr "Cancel invite"
+
 msgid "Invalid username"
 msgstr "Invalid username"
 
@@ -914,11 +920,8 @@ msgstr "Password of user \"{{- name}}\" reset successfuly"
 msgid "There was an error resetting the password: {{- error}}"
 msgstr "There was an error resetting the password: {{- error}}"
 
-msgid "Reset password of user {{- name}}"
-msgstr "Reset password of user {{- name}}"
-
-msgid "Are you sure you want to reset {{- name}}'s password?"
-msgstr "Are you sure you want to reset {{- name}}'s password?"
+msgid "Are you sure you want to reset the password for {{- name}}?"
+msgstr "Are you sure you want to reset the password for {{- name}}?"
 
 msgid "Yes, reset"
 msgstr "Yes, reset"
@@ -956,11 +959,14 @@ msgstr "User Management"
 msgid "Last login"
 msgstr "Last login"
 
-msgid "Account disabled?"
-msgstr "Account disabled?"
+msgid "Status"
+msgstr "Status"
 
 msgid "Disabled"
 msgstr "Disabled"
+
+msgid "Active"
+msgstr "Active"
 
 msgid "Male"
 msgstr "Male"

--- a/src/components/BulkMemberManager/BulkMemberManager.module.css
+++ b/src/components/BulkMemberManager/BulkMemberManager.module.css
@@ -4,7 +4,7 @@
 
 .grid {
     display: grid;
-    max-width: 900px;
+    max-width: 1800px;
     grid-template-columns: 2fr 1fr;
     gap: var(--spacers-dp8);
     margin-top: var(--spacers-dp12);

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.js
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.js
@@ -8,18 +8,10 @@ import {
     IconCross16,
     colors,
 } from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './ResultsTableRow.module.css'
-
-const getRowClass = (pendingChangeAction) => {
-    switch (pendingChangeAction) {
-        case 'ADD':
-            return styles.pendingAddRow
-        case 'REMOVE':
-            return styles.pendingRemoveRow
-    }
-}
 
 const PendingChange = ({ action, onCancel }) => (
     <div className={styles.pendingChange}>
@@ -57,7 +49,12 @@ const ResultsTableRow = ({
     selected,
     onToggleSelected,
 }) => (
-    <DataTableRow className={getRowClass(pendingChangeAction)}>
+    <DataTableRow
+        className={cx(styles.row, {
+            [styles.pendingAddRow]: pendingChangeAction === 'ADD',
+            [styles.pendingRemoveRow]: pendingChangeAction === 'REMOVE',
+        })}
+    >
         <DataTableCell width="48px">
             <Checkbox
                 checked={selected}
@@ -68,7 +65,7 @@ const ResultsTableRow = ({
         {cells.map((cell, index) => (
             <DataTableCell key={index}>{cell}</DataTableCell>
         ))}
-        <DataTableCell>
+        <DataTableCell className={styles.actionCell}>
             {pendingChangeAction ? (
                 <PendingChange
                     action={pendingChangeAction}

--- a/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.module.css
+++ b/src/components/BulkMemberManager/ResultsTable/ResultsTableRow.module.css
@@ -23,3 +23,7 @@
 .pendingRemoveRow .pendingChangeDescription {
     color: var(--colors-red700);
 }
+
+tr.row td.actionCell {
+    width: 320px;
+}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -281,7 +281,14 @@ TransferField.propTypes = {
     required: PropTypes.bool,
 }
 
-const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
+const Form = ({
+    loading,
+    error,
+    children,
+    submitButtonLabel,
+    cancelButtonLabel,
+    onSubmit,
+}) => {
     const history = useHistory()
     const handleCancel = () => history.goBack()
 
@@ -331,7 +338,7 @@ const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
                             {submitButtonLabel}
                         </Button>
                         <Button onClick={handleCancel} disabled={submitting}>
-                            {i18n.t('Cancel without saving')}
+                            {cancelButtonLabel}
                         </Button>
                     </ButtonStrip>
                 </form>
@@ -340,10 +347,15 @@ const Form = ({ loading, error, children, submitButtonLabel, onSubmit }) => {
     )
 }
 
+Form.defaultProps = {
+    cancelButtonLabel: i18n.t('Cancel without saving'),
+}
+
 Form.propTypes = {
     children: PropTypes.func.isRequired,
     submitButtonLabel: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    cancelButtonLabel: PropTypes.string,
     error: PropTypes.instanceOf(Error),
     loading: PropTypes.bool,
 }

--- a/src/components/UserForm/InviteUserSection.js
+++ b/src/components/UserForm/InviteUserSection.js
@@ -1,9 +1,18 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useField } from 'react-final-form'
 import { FormSection, SingleSelectField } from '../Form.js'
 
-const InviteUserSection = ({ user, emailConfigured }) => {
+const InviteUserSection = ({ user, emailConfigured, setIsInvite }) => {
+    const {
+        input: { value },
+    } = useField('inviteUser', { subscription: { value: true } })
+
+    useEffect(() => {
+        setIsInvite(value === 'INVITE_USER')
+    }, [value, setIsInvite])
+
     if (user || !emailConfigured) {
         return null
     }
@@ -31,6 +40,7 @@ const InviteUserSection = ({ user, emailConfigured }) => {
 
 InviteUserSection.propTypes = {
     emailConfigured: PropTypes.bool,
+    setIsInvite: PropTypes.func,
     user: PropTypes.object,
 }
 

--- a/src/components/UserForm/UserForm.js
+++ b/src/components/UserForm/UserForm.js
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import { NoticeBox, FinalForm } from '@dhis2/ui'
 import { keyBy } from 'lodash-es'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import { useCurrentUser } from '../../hooks/useCurrentUser.js'
 import Attributes from '../Attributes/index.js'
@@ -29,6 +29,7 @@ const UserForm = ({
     const {
         systemInfo: { emailConfigured },
     } = useConfig()
+    const [isInvite, setIsInvite] = useState(false)
     const history = useHistory()
     const engine = useDataEngine()
     const {
@@ -141,7 +142,14 @@ const UserForm = ({
         <Form
             loading={loading}
             error={error}
-            submitButtonLabel={submitButtonLabel}
+            submitButtonLabel={
+                isInvite ? i18n.t('Send invite') : submitButtonLabel
+            }
+            cancelButtonLabel={
+                isInvite
+                    ? i18n.t('Cancel invite')
+                    : i18n.t('Cancel without saving')
+            }
             onSubmit={handleSubmit}
         >
             {({ values, submitError }) => (
@@ -162,6 +170,7 @@ const UserForm = ({
                     <InviteUserSection
                         user={user}
                         emailConfigured={emailConfigured}
+                        setIsInvite={setIsInvite}
                     />
                     <BasicInformationSection
                         user={user}

--- a/src/pages/GroupList/ContextMenu/ContextMenu.js
+++ b/src/pages/GroupList/ContextMenu/ContextMenu.js
@@ -109,7 +109,10 @@ const ContextMenu = ({
                 <CurrentModal
                     group={group}
                     refetchGroups={refetchGroups}
-                    onClose={() => setCurrentModal(null)}
+                    onClose={() => {
+                        onClose()
+                        setCurrentModal(null)
+                    }}
                 />
             )}
         </>

--- a/src/pages/RoleList/ContextMenu/ContextMenu.js
+++ b/src/pages/RoleList/ContextMenu/ContextMenu.js
@@ -84,7 +84,10 @@ const ContextMenu = ({ role, anchorRef, refetchRoles, onClose }) => {
                 <CurrentModal
                     role={role}
                     refetchRoles={refetchRoles}
-                    onClose={() => setCurrentModal(null)}
+                    onClose={() => {
+                        onClose()
+                        setCurrentModal(null)
+                    }}
                 />
             )}
         </>

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -31,7 +31,7 @@ const useCurrentModal = () => {
 
     return [
         CurrentModal,
-        Modal => {
+        (Modal) => {
             // As setState supports functional updates, we can't pass functional
             // components directly
             setCurrentModal(() => Modal)

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -155,7 +155,10 @@ const ContextMenu = ({
                 <CurrentModal
                     user={user}
                     refetchUsers={refetchUsers}
-                    onClose={() => setCurrentModal(null)}
+                    onClose={() => {
+                        onClose()
+                        setCurrentModal(null)
+                    }}
                 />
             )}
         </>

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -63,7 +63,7 @@ const ContextMenu = ({
         user.email &&
         access.update &&
         (currentUser.authorities.has('ALL') ||
-            currentUser.authorities.has('F_REPLICATE_USER') ||
+            currentUser.authorities.has('F_USER_ADD') ||
             currentUser.authorities.has('F_USER_ADD_WITHIN_MANAGED_GROUP'))
     const canDisable = currentUser.id !== user.id && access.update && !disabled
     const canDelete = currentUser.id !== user.id && access.delete

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -31,7 +31,7 @@ const useCurrentModal = () => {
 
     return [
         CurrentModal,
-        (Modal) => {
+        Modal => {
             // As setState supports functional updates, we can't pass functional
             // components directly
             setCurrentModal(() => Modal)
@@ -55,12 +55,15 @@ const ContextMenu = ({
         userCredentials: { disabled, twoFA },
     } = user
     const canReplicate =
-        access.update && currentUser.authorities.has('F_REPLICATE_USER')
+        access.update &&
+        (currentUser.authorities.has('ALL') ||
+            currentUser.authorities.has('F_REPLICATE_USER'))
     const canResetPassword =
         emailConfigured &&
         user.email &&
         access.update &&
-        (currentUser.authorities.has('F_USER_ADD') ||
+        (currentUser.authorities.has('ALL') ||
+            currentUser.authorities.has('F_REPLICATE_USER') ||
             currentUser.authorities.has('F_USER_ADD_WITHIN_MANAGED_GROUP'))
     const canDisable = currentUser.id !== user.id && access.update && !disabled
     const canDelete = currentUser.id !== user.id && access.delete

--- a/src/pages/UserList/ContextMenu/Modals/ResetPasswordModal.js
+++ b/src/pages/UserList/ContextMenu/Modals/ResetPasswordModal.js
@@ -47,14 +47,10 @@ const ResetPasswordModal = ({ user, onClose }) => {
 
     return (
         <Modal small>
-            <ModalTitle>
-                {i18n.t('Reset password of user {{- name}}', {
-                    name: user.displayName,
-                })}
-            </ModalTitle>
+            <ModalTitle>{i18n.t('Reset password')}</ModalTitle>
             <ModalContent>
                 {i18n.t(
-                    `Are you sure you want to reset {{- name}}'s password?`,
+                    `Are you sure you want to reset the password for {{- name}}?`,
                     { name: user.displayName }
                 )}
             </ModalContent>

--- a/src/pages/UserList/UserTable.js
+++ b/src/pages/UserList/UserTable.js
@@ -72,7 +72,7 @@ const UserTable = ({
                         {i18n.t('Last login')}
                     </DataTableColumnHeader>
                     <DataTableColumnHeader>
-                        {i18n.t('Account disabled?')}
+                        {i18n.t('Status')}
                     </DataTableColumnHeader>
                     <DataTableColumnHeader>
                         {i18n.t('Actions')}
@@ -109,7 +109,9 @@ const UserTable = ({
                                 )}
                             </DataTableCell>
                             <DataTableCell onClick={handleClick}>
-                                {disabled && i18n.t('Disabled')}
+                                {disabled
+                                    ? i18n.t('Disabled')
+                                    : i18n.t('Active')}
                             </DataTableCell>
                             <DataTableCell>
                                 <ContextMenuButton

--- a/src/pages/UserList/UserTable.test.js
+++ b/src/pages/UserList/UserTable.test.js
@@ -126,7 +126,7 @@ describe('<UserTable>', () => {
             screen.getByRole('columnheader', { name: 'Last login' })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('columnheader', { name: 'Account disabled?' })
+            screen.getByRole('columnheader', { name: 'Status' })
         ).toBeInTheDocument()
         expect(
             screen.getByRole('columnheader', { name: 'Actions' })


### PR DESCRIPTION
see https://dhis2.atlassian.net/browse/DHIS2-15524

This PR cherry picks changes to catch up some bugs/UI changes unaddressed in v39:

- User creation via email invite has buttons "Send invite"/"Cancel invite"
- the reset password text is updated (removes possessive with s)
- user with all authority can now see 'reset password' option in user context menu 
- context menu will now close when a modal is closed
- user list has "status" column (with active/disabled) instead of 'Account disabled?' column
- bulk user editor can expand to 1800px width (rather than 900px)