### PR TITLE
fix: hide x scrollbar in replicate user [DHIS2-15611]

### DIFF
--- a/src/pages/UserList/ContextMenu/Modals/ReplicateModal.js
+++ b/src/pages/UserList/ContextMenu/Modals/ReplicateModal.js
@@ -62,7 +62,7 @@ const ReplicateModal = ({ user, refetchUsers, onClose }) => {
                             name: user.displayName,
                         })}
                     </ModalTitle>
-                    <ModalContent>
+                    <ModalContent className={styles.modalContent}>
                         <form onSubmit={handleSubmit}>
                             <TextField
                                 name="username"

--- a/src/pages/UserList/ContextMenu/Modals/ReplicateModal.module.css
+++ b/src/pages/UserList/ContextMenu/Modals/ReplicateModal.module.css
@@ -2,3 +2,7 @@
     max-width: 250px;
     margin-bottom: var(--spacers-dp8);
 }
+
+.modalContent {
+    overflow-x: hidden;
+}


### PR DESCRIPTION
Disables scroll on user replicate modal. It seems that when we get the loader spinner next to the input, the width exceeds the  parent div (I assume). I've just taken the easiest approach of disabling the scroll as there does not appear to be a situation where we would want the user to be able to scroll within the modal.

**Current**

![userReplicateScroll_before](https://github.com/dhis2/user-app/assets/18490902/cb5334cb-7e1a-4a3d-9d9d-b8e4b9c446c8)

**After**
![userReplicateScroll_after](https://github.com/dhis2/user-app/assets/18490902/26664a74-8169-4a74-b037-6b2e87a87e38)
