### PR TITLE
fix: org unit access in search [DHIS2-16268]

### DIFF
--- a/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.js
+++ b/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.js
@@ -13,7 +13,7 @@ export const getRestrictedOrgUnits = (orgUnits, orgUnitType, currentUser) => {
 
     // Try the requested orgUnitType first and use currentUser.organisationUnits as fallback
     const availableOrgUnits =
-        currentUser[orgUnitType].length > 0
+        currentUser[orgUnitType]?.length > 0
             ? currentUser[orgUnitType]
             : currentUser.organisationUnits
 

--- a/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.js
+++ b/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.js
@@ -12,18 +12,19 @@ export const getRestrictedOrgUnits = (orgUnits, orgUnitType, currentUser) => {
     }
 
     // Try the requested orgUnitType first and use currentUser.organisationUnits as fallback
-    const availableOrgUnits = new Set(
+    const availableOrgUnits =
         currentUser[orgUnitType].length > 0
             ? currentUser[orgUnitType]
             : currentUser.organisationUnits
-    )
+
+    const availableOrgUnitIDs = new Set(availableOrgUnits.map(({ id }) => id))
 
     return orgUnits.filter((unit) => {
-        const isAvailableUnit = availableOrgUnits.has(unit.id)
+        const isAvailableUnit = availableOrgUnitIDs.has(unit.id)
         const hasAvailableAncestor =
             !isAvailableUnit &&
             unit.ancestors.some((ancestor) =>
-                availableOrgUnits.has(ancestor.id)
+                availableOrgUnitIDs.has(ancestor.id)
             )
 
         return isAvailableUnit || hasAvailableAncestor

--- a/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.test.js
+++ b/src/components/SearchableOrgUnitTree/AsyncAutoComplete/getRestrictedOrgUnits.test.js
@@ -1,0 +1,72 @@
+import { getRestrictedOrgUnits } from './getRestrictedOrgUnits.js'
+
+describe('getRestrictedOrgUnits', () => {
+    const orgUnits = [
+        { id: 'grapefruit', ancestors: [{ id: 'pomelo' }] },
+        { id: 'tangerine', ancestors: [{ id: 'orange' }, { id: 'pomelo' }] },
+        { id: 'lemon', ancestors: [] },
+    ]
+    const orgUnitType = 'fruit'
+
+    it('returns all organisation units for super users', () => {
+        const currentUser = { authorities: ['ALL'] }
+        const validOrgUnits = getRestrictedOrgUnits(
+            orgUnits,
+            orgUnitType,
+            currentUser
+        )
+        expect(validOrgUnits).toEqual(orgUnits)
+    })
+    it('filters based on specified type when available', () => {
+        const currentUser = {
+            authorities: [],
+            fruit: [{ id: 'grapefruit' }, { id: 'kiwi' }, { id: 'mango' }],
+        }
+        const validOrgUnits = getRestrictedOrgUnits(
+            orgUnits,
+            orgUnitType,
+            currentUser
+        )
+        expect(validOrgUnits.map(({ id }) => id)).toEqual(['grapefruit'])
+    })
+    it('filters based on default organisationUnits specified type is not available', () => {
+        const currentUser = {
+            authorities: [],
+            organisationUnits: [
+                { id: 'tangerine' },
+                { id: 'soursop' },
+                { id: 'apricot' },
+            ],
+        }
+        const validOrgUnits = getRestrictedOrgUnits(
+            orgUnits,
+            orgUnitType,
+            currentUser
+        )
+        expect(validOrgUnits.map(({ id }) => id)).toEqual(['tangerine'])
+    })
+    it('checks ancestors when filtering', () => {
+        const currentUser = {
+            authorities: [],
+            organisationUnits: [{ id: 'pomelo' }],
+        }
+        const validOrgUnits = getRestrictedOrgUnits(
+            orgUnits,
+            orgUnitType,
+            currentUser
+        )
+        expect(validOrgUnits.map(({ id }) => id)).toEqual([
+            'grapefruit',
+            'tangerine',
+        ])
+    })
+    it('returns nothing, if user is not super user and has no org units', () => {
+        const currentUser = { authorities: [], organisationUnits: [] }
+        const validOrgUnits = getRestrictedOrgUnits(
+            orgUnits,
+            orgUnitType,
+            currentUser
+        )
+        expect(validOrgUnits.length).toEqual(0)
+    })
+})


### PR DESCRIPTION
This fixes an issue where organisation units were not appearing in search results because the user was deemed not to have access to the organisation unit. **Note: this issue was for users without ALL authority** (e.g. `admin` on our play instances)

Issue was that the code was assuming that api/me returned an array of orgUnit ids, but instead we are getting an array of objects like [{id: "someOrgUnit"}] (maybe this was an api change at some point?)

**Before**
<img width="419" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/7ae5e90d-0bf5-4d56-9dbb-26941be9c113">


**After**
<img width="470" alt="image" src="https://github.com/dhis2/user-app/assets/18490902/fb99a367-3c4b-4289-904f-feb6847526b3">


(P.S. I noticed another bug that if you have clicked on multiple of these org unit selection search fields, the search results will appear in all of them, but I don't want to look at/fix that here)