### PR TITLE
fix: remove members references from user group form [DHIS2-16766]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-12-12T13:36:05.060Z\n"
-"PO-Revision-Date: 2023-12-12T13:36:05.060Z\n"
+"POT-Creation-Date: 2024-02-08T17:31:59.581Z\n"
+"PO-Revision-Date: 2024-02-08T17:31:59.581Z\n"
 
 msgid "Yes"
 msgstr "Yes"
@@ -50,14 +50,51 @@ msgstr "There was an error fetching this form."
 msgid "Cancel without saving"
 msgstr "Cancel without saving"
 
+msgid "Basic information"
+msgstr "Basic information"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Code"
+msgstr "Code"
+
+msgid "Used in analytics reports."
+msgstr "Used in analytics reports."
+
 msgid "Error updating group"
 msgstr "Error updating group"
 
 msgid "Error creating group"
 msgstr "Error creating group"
 
+msgid "User management"
+msgstr "User management"
+
+msgid "Add or remove users from this group."
+msgstr "Add or remove users from this group."
+
+msgid ""
+"To add a user to this group, go to the User section and edit the user group "
+"settings for a specific user."
+msgstr ""
+"To add a user to this group, go to the User section and edit the user group "
+"settings for a specific user."
+
 msgid "Attributes"
 msgstr "Attributes"
+
+msgid "User group management"
+msgstr "User group management"
+
+msgid "This group can manage other user groups. Add managed user groups below."
+msgstr "This group can manage other user groups. Add managed user groups below."
+
+msgid "Available user groups"
+msgstr "Available user groups"
+
+msgid "Managed user groups"
+msgstr "Managed user groups"
 
 msgid "Name is already taken"
 msgstr "Name is already taken"
@@ -94,12 +131,6 @@ msgstr "Error updating role"
 
 msgid "Error creating role"
 msgstr "Error creating role"
-
-msgid "Basic information"
-msgstr "Basic information"
-
-msgid "Name"
-msgstr "Name"
 
 msgid "Description"
 msgstr "Description"
@@ -480,9 +511,6 @@ msgstr "Available user roles"
 
 msgid "User roles this user is assigned"
 msgstr "User roles this user is assigned"
-
-msgid "Available user groups"
-msgstr "Available user groups"
 
 msgid "User groups this user is a member of"
 msgstr "User groups this user is a member of"

--- a/src/components/GroupForm/createRequestBody.js
+++ b/src/components/GroupForm/createRequestBody.js
@@ -3,12 +3,11 @@ import { getAttributeValues } from '../../attributes.js'
 const ATTRIBUTE_VALUES = 'attributeValues'
 
 export const createPostRequestBody = ({ values, attributes }) => {
-    const { name, code, members, managedGroups } = values
+    const { name, code, managedGroups } = values
 
     return {
         name,
         code,
-        users: members.additions.map(({ id }) => ({ id })),
         managedGroups: managedGroups.map(id => ({ id })),
         attributeValues: getAttributeValues({ attributes, values }),
     }
@@ -23,7 +22,7 @@ export const createJsonPatchRequestBody = ({
         key => dirtyFields[key]
     )
     const patch = dirtyFieldsArray.reduce((acc, key) => {
-        if (key !== 'members' && !key.startsWith(ATTRIBUTE_VALUES)) {
+        if (!key.startsWith(ATTRIBUTE_VALUES)) {
             const value =
                 key === 'managedGroups'
                     ? values[key].map(id => ({ id }))
@@ -50,24 +49,6 @@ export const createJsonPatchRequestBody = ({
             path: `/${ATTRIBUTE_VALUES}`,
             value: getAttributeValues({ attributes, values }),
         })
-    }
-
-    if (dirtyFields.members) {
-        const { additions, removals } = values.members
-        for (const addition of additions) {
-            patch.push({
-                op: 'add',
-                path: '/users/-',
-                value: { id: addition.id },
-            })
-        }
-        for (const removal of removals) {
-            patch.push({
-                op: 'remove-by-id',
-                path: '/users',
-                id: removal.id,
-            })
-        }
     }
 
     return patch


### PR DESCRIPTION
I made an update for https://github.com/dhis2/user-app/pull/1328 to backport some changes for user group form (and to fix a bug where one could not edit groups assigned to user groups).

However, the code I backported had references to members (which are not editable on v38 because bulk member edit is not a feature there). As a result, an error occurred when saving a new user group ([DHIS2-16766](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-16766))

This PR removes the references to members on user group add and edit (the code for edit didn't do anything because there is no members field in the form).

I've tested to confirm that I can create a new user group and edit the user group management for existing user groups

[DHIS2-16766]: https://dhis2.atlassian.net/browse/DHIS2-16766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ