### PR TITLE
fix: update user group details update

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-02-08T17:31:59.581Z\n"
-"PO-Revision-Date: 2024-02-08T17:31:59.581Z\n"
+"POT-Creation-Date: 2024-03-22T08:26:32.388Z\n"
+"PO-Revision-Date: 2024-03-22T08:26:32.388Z\n"
 
 msgid "Yes"
 msgstr "Yes"
@@ -37,6 +37,9 @@ msgstr "Edit user role"
 
 msgid "Send message"
 msgstr "Send message"
+
+msgid "ID"
+msgstr "ID"
 
 msgid "Filter options"
 msgstr "Filter options"
@@ -605,9 +608,6 @@ msgstr "Create, modify, view and delete User Groups"
 
 msgid "Display name"
 msgstr "Display name"
-
-msgid "ID"
-msgstr "ID"
 
 msgid "Last login"
 msgstr "Last login"

--- a/src/components/DetailSummary.js
+++ b/src/components/DetailSummary.js
@@ -83,8 +83,19 @@ class DetailSummary extends Component {
     }
 
     renderPropertyFields() {
-        const { summaryObject, config } = this.props
+        const { summaryObject, config, baseName } = this.props
         const labelCellStyle = { ...styles.cell, ...styles.valueCell }
+
+        if (baseName === USER_GROUP) {
+            const idLabel = i18n.t('ID')
+            const idValue = summaryObject['id'] || ''
+            return (
+                <tr>
+                    <td style={labelCellStyle}>{idLabel}</td>
+                    <td style={styles.cell}>{idValue}</td>
+                </tr>
+            )
+        }
 
         return config.map((field, index) => {
             const {


### PR DESCRIPTION
Implements [Jira ticket](https://dhis2.atlassian.net/browse/DHIS2-12079)
---

### Description
Implemented a modification to the `renderPropertyFields` function on the group details page to render only the ID field on user group page and its corresponding value.

---

### Known issues

-   [ ] None

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots
<img width="1440" alt="Screenshot 2024-03-18 at 10 49 18" src="https://github.com/dhis2/user-app/assets/87203527/0b779132-988a-43e8-82a6-75511183d876">
