### PR TITLE
feat: add a default notice box based on access level of the user

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-01-19T12:15:17.744Z\n"
-"PO-Revision-Date: 2024-01-19T12:15:17.744Z\n"
+"POT-Creation-Date: 2024-03-27T09:03:25.496Z\n"
+"PO-Revision-Date: 2024-03-27T09:03:25.496Z\n"
 
 msgid "Yes"
 msgstr "Yes"
@@ -703,6 +703,9 @@ msgstr "There was an error fetching this user."
 
 msgid "Edit user"
 msgstr "Edit user"
+
+msgid "You do not have access to edit this user group"
+msgstr "You do not have access to edit this user group"
 
 msgid "Overview"
 msgstr "Overview"

--- a/src/pages/GroupDetails/GroupDetails.js
+++ b/src/pages/GroupDetails/GroupDetails.js
@@ -34,6 +34,12 @@ const GroupDetails = ({ groupId }) => {
 
     return (
         <Details title={group.displayName}>
+            {group.access.read && (
+                <NoticeBox warn>
+                    {i18n.t('You do not have access to edit this user group')}
+                </NoticeBox>
+            )}
+            <br />
             <Section
                 title={i18n.t('Overview')}
                 action={

--- a/src/pages/GroupDetails/GroupDetails.js
+++ b/src/pages/GroupDetails/GroupDetails.js
@@ -34,7 +34,7 @@ const GroupDetails = ({ groupId }) => {
 
     return (
         <Details title={group.displayName}>
-            {group.access.read && (
+            {!group?.access?.write && (
                 <NoticeBox warn>
                     {i18n.t('You do not have access to edit this user group')}
                 </NoticeBox>


### PR DESCRIPTION
Implements [DHIS2-17083](https://dhis2.atlassian.net/browse/DHIS2-17083)
---

### Description
conditionally display update status in user group details page based on access levels

---

### Known issues

-   [ ] None

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots
<img width="1440" alt="Screenshot 2024-03-27 at 08 59 18" src="https://github.com/dhis2/user-app/assets/87203527/23b72bae-97cb-47fa-aa45-6e0c3c431d08">


[DHIS2-17083]: https://dhis2.atlassian.net/browse/DHIS2-17083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ