### PR TITLE
fix: ignore case when sorting grouped authorities by name

### DIFF
--- a/src/components/RoleForm/groupAuthorities/groupAuthorities.js
+++ b/src/components/RoleForm/groupAuthorities/groupAuthorities.js
@@ -72,7 +72,9 @@ const groupForAuthority = (auth) => {
 const sortGroupedAuthorities = (groupedAuthorities) => {
     const sortedGroupedAuthorities = {}
     for (const [group, items] of Object.entries(groupedAuthorities)) {
-        sortedGroupedAuthorities[group] = sortBy(items, 'name')
+        sortedGroupedAuthorities[group] = sortBy(items, (item) =>
+            item.name?.toLowerCase()
+        )
     }
     return sortedGroupedAuthorities
 }


### PR DESCRIPTION
Fixes [DHIS2-10843](https://dhis2.atlassian.net/browse/DHIS2-10843).

Authorities are now sorted ignoring case as per image below
<img width="713" alt="Screenshot 2024-07-15 at 07 25 57" src="https://github.com/user-attachments/assets/58113ead-c8d5-4fae-af95-cc1c5450b135">


[DHIS2-10843]: https://dhis2.atlassian.net/browse/DHIS2-10843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ