### PR TITLE
fix: add capture authority to tracker list

### DIFF
--- a/src/components/RoleForm/groupAuthorities/groupAuthorities.js
+++ b/src/components/RoleForm/groupAuthorities/groupAuthorities.js
@@ -20,7 +20,7 @@ const AUTHORITY_GROUPS = {
         'F_TRACKER_IMPORTER_EXPERIMENTAL',
         'F_UNCOMPLETE_EVENT',
         'F_VIEW_EVENT_ANALYTICS',
-        'F_CAPTURE_DATASTORE_UPDATE'
+        'F_CAPTURE_DATASTORE_UPDATE',
     ]),
     importExport: new Set([
         'F_EXPORT_DATA',

--- a/src/components/RoleForm/groupAuthorities/groupAuthorities.js
+++ b/src/components/RoleForm/groupAuthorities/groupAuthorities.js
@@ -20,6 +20,7 @@ const AUTHORITY_GROUPS = {
         'F_TRACKER_IMPORTER_EXPERIMENTAL',
         'F_UNCOMPLETE_EVENT',
         'F_VIEW_EVENT_ANALYTICS',
+        'F_CAPTURE_DATASTORE_UPDATE'
     ]),
     importExport: new Set([
         'F_EXPORT_DATA',


### PR DESCRIPTION
Adds the `F_CAPTURE_DATASTORE_UPDATE` to the tracker authority list.