### PR TITLE
fix: reset 2fa button [DHIS2-18831]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-17T10:45:40.388Z\n"
-"PO-Revision-Date: 2025-02-17T10:45:40.388Z\n"
+"POT-Creation-Date: 2025-02-21T10:16:54.865Z\n"
+"PO-Revision-Date: 2025-02-21T10:16:54.865Z\n"
 
 msgid "Yes"
 msgstr "Yes"
@@ -894,29 +894,14 @@ msgstr "Disable"
 msgid "Enable"
 msgstr "Enable"
 
-msgid "Disable Two Factor Authentication"
-msgstr "Disable Two Factor Authentication"
+msgid "Reset two factor authentication"
+msgstr "Reset two factor authentication"
 
 msgid "There was an error deleting the user: {{- error}}"
 msgstr "There was an error deleting the user: {{- error}}"
 
 msgid "Delete user {{- name}}"
 msgstr "Delete user {{- name}}"
-
-msgid "Disabled two factor authentication for \"{{- name}}\" successfuly"
-msgstr "Disabled two factor authentication for \"{{- name}}\" successfuly"
-
-msgid "There was an error disabling two factor authentication: {{- error}}"
-msgstr "There was an error disabling two factor authentication: {{- error}}"
-
-msgid "Disable two factor authentication for user {{- name}}"
-msgstr "Disable two factor authentication for user {{- name}}"
-
-msgid "Are you sure you want to disable two factor authentication for {{- name}}?"
-msgstr "Are you sure you want to disable two factor authentication for {{- name}}?"
-
-msgid "Yes, disable two factor authentication"
-msgstr "Yes, disable two factor authentication"
 
 msgid "User \"{{- name}}\" disabled successfuly"
 msgstr "User \"{{- name}}\" disabled successfuly"
@@ -977,6 +962,24 @@ msgstr "Are you sure you want to reset the password for {{- name}}?"
 
 msgid "Yes, reset"
 msgstr "Yes, reset"
+
+msgid "Two factor authentication for \"{{- name}}\" has reset successfully"
+msgstr "Two factor authentication for \"{{- name}}\" has reset successfully"
+
+msgid "There was an error resetting the two factor authentication: {{- error}}"
+msgstr "There was an error resetting the two factor authentication: {{- error}}"
+
+msgid ""
+"If {{- name}} has two factor authentication enabled, resetting the two "
+"factor authentication will make it possible for them to log in without "
+"providing a two factor authentication code."
+msgstr ""
+"If {{- name}} has two factor authentication enabled, resetting the two "
+"factor authentication will make it possible for them to log in without "
+"providing a two factor authentication code."
+
+msgid "Are you sure you want to reset two factor authentication for {{- name}}?"
+msgstr "Are you sure you want to reset two factor authentication for {{- name}}?"
 
 msgid "1 month"
 msgstr "1 month"

--- a/src/pages/UserList/ContextMenu/ContextMenu.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.js
@@ -20,11 +20,11 @@ import React, { useState } from 'react'
 import { useCurrentUser, useReferrerInfo } from '../../../providers/index.js'
 import navigateTo from '../../../utils/navigateTo.js'
 import DeleteModal from './Modals/DeleteModal.js'
-import Disable2FaModal from './Modals/Disable2FaModal.js'
 import DisableModal from './Modals/DisableModal.js'
 import EnableModal from './Modals/EnableModal.js'
 import ReplicateModal from './Modals/ReplicateModal.js'
 import ResetPasswordModal from './Modals/ResetPasswordModal.js'
+import ResetTwoFAModal from './Modals/ResetTwoFAModal.js'
 
 const useCurrentModal = () => {
     const [CurrentModal, setCurrentModal] = useState()
@@ -45,7 +45,7 @@ const ContextMenu = ({ user, anchorRef, refetchUsers, onClose }) => {
         systemInfo: { emailConfigured },
     } = useConfig()
     const [CurrentModal, setCurrentModal] = useCurrentModal()
-    const { access, twoFactorEnabled, disabled } = user
+    const { access, disabled } = user
     const canReplicate =
         access.update &&
         currentUser.authorities.some(
@@ -63,6 +63,7 @@ const ContextMenu = ({ user, anchorRef, refetchUsers, onClose }) => {
         )
     const canDisable = currentUser.id !== user.id && access.update && !disabled
     const canDelete = currentUser.id !== user.id && access.delete
+    const canReset2FA = currentUser.id !== user.id && access.update
     const { setReferrer } = useReferrerInfo()
 
     return (
@@ -127,13 +128,13 @@ const ContextMenu = ({ user, anchorRef, refetchUsers, onClose }) => {
                                 dense
                             />
                         )}
-                        {access.update && twoFactorEnabled && (
+                        {canReset2FA && (
                             <MenuItem
                                 label={i18n.t(
-                                    'Disable Two Factor Authentication'
+                                    'Reset two factor authentication'
                                 )}
                                 icon={<IconLockOpen16 color={colors.grey600} />}
-                                onClick={() => setCurrentModal(Disable2FaModal)}
+                                onClick={() => setCurrentModal(ResetTwoFAModal)}
                                 dense
                             />
                         )}
@@ -174,7 +175,6 @@ ContextMenu.propTypes = {
         }).isRequired,
         disabled: PropTypes.bool.isRequired,
         id: PropTypes.string.isRequired,
-        twoFactorEnabled: PropTypes.bool.isRequired,
         email: PropTypes.string,
     }).isRequired,
     onClose: PropTypes.func.isRequired,

--- a/src/pages/UserList/ContextMenu/ContextMenu.test.js
+++ b/src/pages/UserList/ContextMenu/ContextMenu.test.js
@@ -1,0 +1,142 @@
+import { Provider, CustomDataProvider } from '@dhis2/app-runtime'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PropTypes from 'prop-types'
+import React from 'react'
+import ContextMenu from './ContextMenu.js'
+
+jest.mock('../../../providers/current-user/useCurrentUser.js', () => ({
+    useCurrentUser: jest.fn(() => ({ id: 'anotherID01', authorities: [] })),
+}))
+
+const DEFAULT_USER = {
+    access: {
+        delete: false,
+        read: true,
+        update: true,
+    },
+    disabled: false,
+    id: 'userABC1234',
+    email: 'dhis2user@dhis2.org',
+    displayName: 'Nils Holgersson',
+}
+
+const DEFAULT_PROPS = {
+    anchorRef: {},
+    refetchUsers: jest.fn(),
+    onClose: jest.fn(),
+    user: DEFAULT_USER,
+}
+
+const CONFIG_DEFAULTS = {
+    baseUrl: 'https://debug.dhis2.org/dev',
+    apiVersion: '42',
+    systemInfo: {
+        serverTimeZoneId: 'Etc/UTC',
+    },
+}
+
+const mockReset2FA = jest.fn()
+
+const getCustomData = ({ userId }) => ({
+    [`users/${userId}/twoFA/disabled`]: (type) => {
+        mockReset2FA(type)
+    },
+})
+
+const RenderWrapper = ({ userId, children }) => (
+    <Provider config={CONFIG_DEFAULTS}>
+        <CustomDataProvider
+            data={getCustomData({ userId })}
+            queryClientOptions={{}}
+        >
+            {children}
+        </CustomDataProvider>
+    </Provider>
+)
+
+RenderWrapper.propTypes = {
+    children: PropTypes.node,
+    userId: PropTypes.string,
+}
+
+describe('Context Menu', () => {
+    it('should show two factor reset if admin has update access to user object', () => {
+        render(
+            <RenderWrapper>
+                <ContextMenu {...DEFAULT_PROPS} />
+            </RenderWrapper>
+        )
+        expect(
+            screen.getByText('Reset two factor authentication')
+        ).toBeInTheDocument()
+    })
+
+    it('should not show two factor reset if admin does not have update access to user object', () => {
+        const modifiedUser = {
+            ...DEFAULT_USER,
+            access: { ...DEFAULT_USER.access, update: false },
+        }
+        render(
+            <RenderWrapper>
+                <ContextMenu {...DEFAULT_PROPS} user={modifiedUser} />
+            </RenderWrapper>
+        )
+        expect(
+            screen.queryByText('Reset two factor authentication')
+        ).not.toBeInTheDocument()
+    })
+
+    it('should not show two factor reset if admin is modifying themself', () => {
+        const modifiedUser = { ...DEFAULT_USER, id: 'anotherID01' }
+        render(
+            <RenderWrapper>
+                <ContextMenu {...DEFAULT_PROPS} user={modifiedUser} />
+            </RenderWrapper>
+        )
+        expect(
+            screen.queryByText('Reset two factor authentication')
+        ).not.toBeInTheDocument()
+    })
+
+    it('shows explanation about resetting 2FA when Reset 2FA option is clicked', async () => {
+        render(
+            <RenderWrapper>
+                <ContextMenu {...DEFAULT_PROPS} />
+            </RenderWrapper>
+        )
+
+        const resetTwoFAOption = screen.getByText(
+            'Reset two factor authentication'
+        )
+        await waitFor(() => {
+            userEvent.click(resetTwoFAOption)
+        })
+        const explanationText = screen.getByText(
+            'If Nils Holgersson has two factor authentication enabled, resetting the two factor authentication will make it possible for them to log in without providing a two factor authentication code.'
+        )
+        expect(explanationText).toBeInTheDocument()
+    })
+
+    it('calls disable mutation when admin clicks through modal to reset 2FA', async () => {
+        render(
+            <RenderWrapper userId="userABC1234">
+                <ContextMenu {...DEFAULT_PROPS} />
+            </RenderWrapper>
+        )
+
+        const resetTwoFAOption = screen.getByText(
+            'Reset two factor authentication'
+        )
+        await waitFor(() => {
+            userEvent.click(resetTwoFAOption)
+        })
+
+        const resetTwoFAConfirm = screen.getByText('Yes, reset')
+        await waitFor(() => {
+            userEvent.click(resetTwoFAConfirm)
+        })
+        expect(mockReset2FA).toHaveBeenCalledTimes(1)
+        expect(mockReset2FA).toHaveBeenCalledWith('create')
+    })
+})

--- a/src/pages/UserList/ContextMenu/Modals/ResetTwoFAModal.js
+++ b/src/pages/UserList/ContextMenu/Modals/ResetTwoFAModal.js
@@ -11,13 +11,14 @@ import {
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useFetchAlert } from '../../../../hooks/useFetchAlert.js'
+import styles from './ResetTwoFAModal.module.css'
 
-const Disable2FaModal = ({ user, refetchUsers, onClose }) => {
+const ResetTwoFAModal = ({ user, onClose }) => {
     const engine = useDataEngine()
     const [loading, setLoading] = useState(false)
     const { showSuccess, showError } = useFetchAlert()
 
-    const handleDisable2Fa = async () => {
+    const handleReset2FA = async () => {
         setLoading(true)
         try {
             await engine.mutate({
@@ -25,18 +26,17 @@ const Disable2FaModal = ({ user, refetchUsers, onClose }) => {
                 type: 'create',
             })
             const message = i18n.t(
-                'Disabled two factor authentication for "{{- name}}" successfuly',
+                'Two factor authentication for "{{- name}}" has reset successfully',
                 {
                     name: user.displayName,
                 }
             )
             showSuccess(message)
-            refetchUsers()
             onClose()
         } catch (error) {
             setLoading(false)
             const message = i18n.t(
-                'There was an error disabling two factor authentication: {{- error}}',
+                'There was an error resetting the two factor authentication: {{- error}}',
                 {
                     error: error.message,
                     nsSeparator: '-:-',
@@ -47,34 +47,29 @@ const Disable2FaModal = ({ user, refetchUsers, onClose }) => {
     }
 
     return (
-        <Modal>
-            <ModalTitle>
-                {i18n.t(
-                    'Disable two factor authentication for user {{- name}}',
-                    {
-                        name: user.displayName,
-                    }
-                )}
-            </ModalTitle>
+        <Modal small>
+            <ModalTitle>{i18n.t('Reset two factor authentication')}</ModalTitle>
             <ModalContent>
-                {i18n.t(
-                    `Are you sure you want to disable two factor authentication for {{- name}}?`,
-                    {
-                        name: user.displayName,
-                    }
-                )}
+                <div>
+                    {i18n.t(
+                        `If {{- name}} has two factor authentication enabled, resetting the two factor authentication will make it possible for them to log in without providing a two factor authentication code.`,
+                        { name: user.displayName }
+                    )}
+                </div>
+                <div className={styles.secondary2FAModalText}>
+                    {i18n.t(
+                        `Are you sure you want to reset two factor authentication for {{- name}}?`,
+                        { name: user.displayName }
+                    )}
+                </div>
             </ModalContent>
             <ModalActions>
                 <ButtonStrip end>
                     <Button secondary onClick={onClose} disabled={loading}>
                         {i18n.t('No, cancel')}
                     </Button>
-                    <Button
-                        primary
-                        loading={loading}
-                        onClick={handleDisable2Fa}
-                    >
-                        {i18n.t('Yes, disable two factor authentication')}
+                    <Button primary loading={loading} onClick={handleReset2FA}>
+                        {i18n.t('Yes, reset')}
                     </Button>
                 </ButtonStrip>
             </ModalActions>
@@ -82,10 +77,9 @@ const Disable2FaModal = ({ user, refetchUsers, onClose }) => {
     )
 }
 
-Disable2FaModal.propTypes = {
-    refetchUsers: PropTypes.func.isRequired,
+ResetTwoFAModal.propTypes = {
     user: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
 }
 
-export default Disable2FaModal
+export default ResetTwoFAModal

--- a/src/pages/UserList/ContextMenu/Modals/ResetTwoFAModal.module.css
+++ b/src/pages/UserList/ContextMenu/Modals/ResetTwoFAModal.module.css
@@ -1,0 +1,3 @@
+.secondary2FAModalText {
+    margin-block: 8px;
+}


### PR DESCRIPTION
See ticket [DHIS2-18831](https://dhis2.atlassian.net/browse/DHIS2-18831)

This ended up being more of a bug fix than a feature because it turns out we already had a reset two factor authentication item in the context menu. However, we were checking for user.twoFactorEnabled which does not exist on the user object, so we were not displaying it.

After discussion with Morten, we've decided that we will not be exposing information on whether a user has two factor authentication enabled as that could potentially be a security issue to disclose that information more broadly (in the sense that not everyone has a need to know if users have two factor authentication enabled).

As a result, I am updating the app to always display this "Reset two factor authentication" option with some more explanation that resetting the two factor authentication will apply to users with two factor authentication enabled. 

(The ticket has been updated to match what is implemented in this ticket) 

[DHIS2-18831]: https://dhis2.atlassian.net/browse/DHIS2-18831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ