### PR TITLE
fix: disable authority select all when there is a filter [DHIS2-19009]

### DIFF
--- a/src/components/RoleForm/MetadataAuthoritiesTable.js
+++ b/src/components/RoleForm/MetadataAuthoritiesTable.js
@@ -9,6 +9,7 @@ import {
     DataTableColumnHeader,
     DataTableBody,
     DataTableCell,
+    Tooltip,
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -29,20 +30,44 @@ ColumnHeader.propTypes = {
     children: PropTypes.node.isRequired,
 }
 
+const TooltipDisabledWrapper = ({ disabled, children }) => {
+    if (!disabled) {
+        return <>{children}</>
+    }
+    return (
+        <Tooltip
+            content={i18n.t(
+                'Select all is not possible while filter is applied'
+            )}
+        >
+            {children}
+        </Tooltip>
+    )
+}
+
+TooltipDisabledWrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+    disabled: PropTypes.bool,
+}
+
 const CheckboxColumnHeader = ({
     name,
     label,
     selectedColumns,
     onSelectedColumnToggle,
+    disabled,
 }) => (
     <ColumnHeader>
-        <CheckboxField
-            dense
-            name={name}
-            label={label}
-            checked={selectedColumns.has(name)}
-            onChange={() => onSelectedColumnToggle(name)}
-        />
+        <TooltipDisabledWrapper disabled={disabled}>
+            <CheckboxField
+                dense
+                name={name}
+                label={label}
+                checked={selectedColumns.has(name)}
+                onChange={() => onSelectedColumnToggle(name)}
+                disabled={disabled}
+            />
+        </TooltipDisabledWrapper>
     </ColumnHeader>
 )
 
@@ -51,6 +76,7 @@ CheckboxColumnHeader.propTypes = {
     name: PropTypes.string.isRequired,
     selectedColumns: PropTypes.instanceOf(Set).isRequired,
     onSelectedColumnToggle: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 }
 
 const AuthorityCell = React.memo(
@@ -181,24 +207,28 @@ const MetadataAuthoritiesTable = React.memo(
                             label={i18n.t('Add/Update Public')}
                             selectedColumns={selectedColumns}
                             onSelectedColumnToggle={onSelectedColumnToggle}
+                            disabled={Boolean(filter)}
                         />
                         <CheckboxColumnHeader
                             name="addUpdatePrivate"
                             label={i18n.t('Add/Update Private')}
                             selectedColumns={selectedColumns}
                             onSelectedColumnToggle={onSelectedColumnToggle}
+                            disabled={Boolean(filter)}
                         />
                         <CheckboxColumnHeader
                             name="delete"
                             label={i18n.t('Delete')}
                             selectedColumns={selectedColumns}
                             onSelectedColumnToggle={onSelectedColumnToggle}
+                            disabled={Boolean(filter)}
                         />
                         <CheckboxColumnHeader
                             name="externalAccess"
                             label={i18n.t('External access')}
                             selectedColumns={selectedColumns}
                             onSelectedColumnToggle={onSelectedColumnToggle}
+                            disabled={Boolean(filter)}
                         />
                     </DataTableRow>
                 </DataTableHead>

--- a/src/components/RoleForm/MetadataAuthoritiesTable.test.js
+++ b/src/components/RoleForm/MetadataAuthoritiesTable.test.js
@@ -1,0 +1,103 @@
+import { ReactFinalForm } from '@dhis2/ui'
+import { act, render, screen } from '@testing-library/react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import MetadataAuthoritiesTable from './MetadataAuthoritiesTable.js'
+
+const { Form } = ReactFinalForm
+
+const noop = () => {}
+
+const RenderWrapper = ({ children }) => (
+    <Form onSubmit={noop}>{() => children}</Form>
+)
+
+RenderWrapper.propTypes = {
+    children: PropTypes.node,
+}
+
+const DEFAULT_METADATA_AUTHORITIES = [
+    {
+        name: 'Chocolate cake',
+        addUpdatePublic: {
+            id: 'F_CHOCOLATE_CAKE_PUBLIC_ADD',
+            name: 'Add/Update Chocolate Cake',
+        },
+        addUpdatePrivate: {
+            id: 'F_CHOCOLATE_CAKE_PRIVATE_ADD',
+            name: 'Add/Update Chocolate Cake',
+        },
+        delete: {
+            id: 'F_CHOCOLATE_CAKE_DELETE',
+            name: 'Delete Chocolate Cake',
+        },
+        externalAccess: {
+            empty: true,
+        },
+    },
+]
+
+const DEFAULT_PROPS = {
+    filter: '',
+    filterSelectedOnly: false,
+    metadataAuthorities: DEFAULT_METADATA_AUTHORITIES,
+    selectedAuthorities: new Set(),
+    selectedColumns: new Set(),
+    onFilterChange: () => {},
+    onFilterSelectedOnlyChange: () => {},
+    onSelectedAuthorityToggle: () => {},
+    onSelectedColumnToggle: () => {},
+}
+
+describe('MetadataAuthoritiesTable', () => {
+    it('should have enabled select all checboxes when filter is empty string', () => {
+        act(() => {
+            render(
+                <RenderWrapper>
+                    <MetadataAuthoritiesTable {...DEFAULT_PROPS} />
+                </RenderWrapper>
+            )
+        })
+        const addPublicCheckbox = screen.getByRole('checkbox', {
+            name: 'Add/Update Public',
+        })
+        expect(addPublicCheckbox).not.toBeDisabled()
+        const addPrivateCheckbox = screen.getByRole('checkbox', {
+            name: 'Add/Update Private',
+        })
+        expect(addPrivateCheckbox).not.toBeDisabled()
+        const deleteCheckbox = screen.getByRole('checkbox', { name: 'Delete' })
+        expect(deleteCheckbox).not.toBeDisabled()
+        const eternalheckbox = screen.getByRole('checkbox', {
+            name: 'External access',
+        })
+        expect(eternalheckbox).not.toBeDisabled()
+    })
+
+    it('should have disabled select all checkboxes when filter is not empty string', async () => {
+        act(() => {
+            render(
+                <RenderWrapper>
+                    <MetadataAuthoritiesTable
+                        {...DEFAULT_PROPS}
+                        filter="cake"
+                    />
+                </RenderWrapper>
+            )
+        })
+        const addPublicCheckbox = screen.getByRole('checkbox', {
+            name: 'Add/Update Public',
+        })
+        expect(addPublicCheckbox).toBeDisabled()
+        const addPrivateCheckbox = screen.getByRole('checkbox', {
+            name: 'Add/Update Private',
+        })
+        expect(addPrivateCheckbox).toBeDisabled()
+        const deleteCheckbox = screen.getByRole('checkbox', { name: 'Delete' })
+        expect(deleteCheckbox).toBeDisabled()
+        const eternalheckbox = screen.getByRole('checkbox', {
+            name: 'External access',
+        })
+        expect(eternalheckbox).toBeDisabled()
+    })
+})


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-19009?jql=project%20%3D%20%22DHIS2%22%20ORDER%20BY%20created%20DESC

As agreed (https://dhis2.atlassian.net/browse/DHIS2-19009?focusedCommentId=209341): this updates the functionality of the "Select all" checkboxes to be disabled when there is a filter. Note that you can first select all, then add a filter and then the checkbox will be disabled, so to unselect everything, you'd have to clear the filter.

I think the UI could still be improved here, but hopefully this is some improvement.

I've also added a tooltip to explain why the checkboxes are disabled:
<img width="310" alt="image" src="https://github.com/user-attachments/assets/08ffa8e4-97c1-4893-b40f-1ab7a5f3ab1a" />

