### PR TITLE
feat: filter out impersonation authority [DHIS2-19324]

### DIFF
--- a/src/providers/system/SystemProvider.jsx
+++ b/src/providers/system/SystemProvider.jsx
@@ -17,6 +17,8 @@ const query = {
     },
 }
 
+const EXCLUDED_AUTHORITIES = ['F_PREVIOUS_IMPERSONATOR_AUTHORITY']
+
 export const SystemProvider = ({ children }) => {
     const { data, error, fetching, loading } = useDataQuery(query)
 
@@ -43,7 +45,10 @@ export const SystemProvider = ({ children }) => {
     }
 
     const value = {
-        authorities: data.systemAuthorities?.systemAuthorities ?? [],
+        authorities:
+            data.systemAuthorities?.systemAuthorities?.filter(
+                (a) => !EXCLUDED_AUTHORITIES.includes(a?.id)
+            ) ?? [],
         authorityIdToNameMap: !data.systemAuthorities?.systemAuthorities
             ? new Map()
             : data.systemAuthorities?.systemAuthorities?.reduce(

--- a/src/providers/system/useSystemInformation.test.js
+++ b/src/providers/system/useSystemInformation.test.js
@@ -1,0 +1,50 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import { SystemProvider } from './SystemProvider.jsx'
+import { useSystemInformation } from './useSystemInformation.js'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useDataQuery: jest.fn(),
+    useConfig: jest.fn(),
+}))
+
+const wrapper = ({ children }) => <SystemProvider>{children}</SystemProvider>
+
+describe('useSystemInformation', () => {
+    it('should filter out F_PREVIOUS_IMPERSONATOR_AUTHORITY from authorities', () => {
+        useDataQuery.mockReturnValue({
+            data: {
+                systemAuthorities: {
+                    systemAuthorities: [
+                        { id: 'cat', name: 'Cat' },
+                        {
+                            id: 'F_PREVIOUS_IMPERSONATOR_AUTHORITY',
+                            name: 'Impersonate name',
+                        },
+                        { id: 'dog', name: 'Dog' },
+                    ],
+                },
+                systemSettings: { keyCanGrantOwnUserAuthorityGroups: true },
+            },
+        })
+        const { result } = renderHook(() => useSystemInformation(), { wrapper })
+
+        expect(result.current.authorities).toStrictEqual([
+            { id: 'cat', name: 'Cat' },
+            { id: 'dog', name: 'Dog' },
+        ])
+    })
+
+    it('returns empty array if authorities are missing from response', () => {
+        useDataQuery.mockReturnValue({
+            data: {
+                systemSettings: { keyCanGrantOwnUserAuthorityGroups: true },
+            },
+        })
+        const { result } = renderHook(() => useSystemInformation(), { wrapper })
+
+        expect(result.current.authorities).toStrictEqual([])
+    })
+})


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-19234

Morten and Jan requested that `F_PREVIOUS_IMPERSONATOR_AUTHORITY` be filtered out as it's not an authority users should add to user roles.


## Notes
I have added logic to filter it out. Filtering it out means that it will appear in the "legacy authorities" section if you had added previously.

The `F_PREVIOUS_IMPERSONATOR_AUTHORITY` is in v41 and v42, so there's no needed feature toggling here.


**Before**
<img width="777" alt="image" src="https://github.com/user-attachments/assets/35b935a8-ddc4-480b-af0a-365842b5f176" />

**After**
<img width="741" alt="image" src="https://github.com/user-attachments/assets/a7a77400-6a2f-4353-94b6-b3d9debd1e39" />

_when in edit mode_
<img width="911" alt="image" src="https://github.com/user-attachments/assets/d4ce93d6-e77f-40c6-8733-0cc6bb13379e" />


## Testing
Manually tested and added some automated tests to check that the authority is filtered out of the authorities provider/useSystemInformation hook.

You can also create a user role with `F_PREVIOUS_IMPERSONATOR_AUTHORITY`/`User Impersonation (switch back)` in normal user app and then check that the role has `F_PREVIOUS_IMPERSONATOR_AUTHORITY` in legacy authorities when editing.
