### PR TITLE
fix: update UI library [DHIS2-19573]

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@dhis2/app-runtime": "^3.13.1",
         "@dhis2/d2-i18n": "^1.1.3",
-        "@dhis2/ui": "^10.1.11",
+        "@dhis2/ui": "^10.14.0",
         "classnames": "^2.3.1",
         "lodash-es": "^4.17.21",
         "memoize-one": "^6.0.0",
@@ -49,5 +49,8 @@
         "redux-logger": "^3.0.6",
         "start-server-and-test": "^1.14.0"
     },
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+    "resolutions": {
+        "@dhis2/ui": "^10.14.0"
+    }    
 }

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
     "resolutions": {
         "@dhis2/ui": "^10.14.0"
-    }    
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,12 +1045,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.23.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.23.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
   dependencies:
     regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.15.4":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
 "@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
   version "7.27.2"
@@ -1471,585 +1476,586 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2-ui/alert@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-10.9.0.tgz#cce30e22c361d1193716c07bd785818752c49b1e"
-  integrity sha512-xb3L8JVIkZSOMgx+xZkgN/6LAKpLXxVP9Z5ABOC7aet6eChZzNZfLY+uyvIWYQbLkLiSRdTaQkJGNRNDvSfCWA==
+"@dhis2-ui/alert@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-10.14.0.tgz#741739f73cfc7d04e617edb1670f345f53ca78e7"
+  integrity sha512-oEMLZD5DcdT1eoDMqj4IPkyBv4ywWFnMcUswfXxOXC6tVKak6BcSyByrxSCo0gf8Lje1ZSbIJ/dzsd9Ws6Pigg==
   dependencies:
-    "@dhis2-ui/portal" "10.9.0"
+    "@dhis2-ui/portal" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/box@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-10.9.0.tgz#61f58b298b2dfd5741e6235138f314caa2ad7e70"
-  integrity sha512-7M8CHuNN8Vezl0uQvkkiNVs+AaHz8GGGt0K9yuX3OCx3LJ+I/NGvAmAzKvOAtidBcvg/Q43psvaKko5aK4z4kQ==
+"@dhis2-ui/box@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-10.14.0.tgz#55322942edd13f7373a46e8f24145c71cdb60386"
+  integrity sha512-KggFQ2f1tbyxbH2aH0aXN42Poa5mZDGPA/aKEqVhGcsSgmYNYZsqqjZLz2l0GrzYMwPfRW9+NS1w9g35bPV+kA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/button@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-10.9.0.tgz#a9827311ce5c2c64e418408e1f458a695a413b58"
-  integrity sha512-9WwwpI3cA3nT9dPSDvMN1ZAQ+Aj78AAZg0aBfyjXfrMzfoRUyCqGolT2+ibCiCH8r5wlfAaVZJWUPFqX18ZQTA==
+"@dhis2-ui/button@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-10.14.0.tgz#be8fb23714c31ae98660e0ee80819a12e6e87d1c"
+  integrity sha512-LjBSng7JmL+4TMsPILvHVmI/6rYDr4nkfYbb8VbxoH/1rXLrA+nnr9LugC/U21Cnbg2wWMgj/wJxP4O+DeUT8Q==
   dependencies:
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/calendar@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/calendar/-/calendar-10.9.0.tgz#66125566f55c5526937fcb2fbb80ff464e4a2b5a"
-  integrity sha512-D+YWQV4zWbZdd+4h0OekJw/3lh06sHR0juzpEniEuyge0faVW5bVcu1kz5Dc8LFZjsLtzEyeHhWf/uxoqFhObw==
+"@dhis2-ui/calendar@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/calendar/-/calendar-10.14.0.tgz#50aa38ab9f6f153785d573eff8e0798dbcb40dac"
+  integrity sha512-jcUreo7ukJHff0gDKw8eHB4vVuebMjkfbj7PS5dOylweWAdb2hnAa8cQ5YUbioM1+iJiORLTOEAzS5kkUCHSUw==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
     "@dhis2/multi-calendar-dates" "2.1.2"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/card@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-10.9.0.tgz#9db2098b6deb7ec0f6f8583d01d77e984931efdb"
-  integrity sha512-pxkx9CNkjQ4OL45/wVJZpswkS0XMydwk5gyLURAyk+M7OuzRC/GMCn1eB2cRne8P44ErTRbyrNDRHxyHUfRZvw==
+"@dhis2-ui/card@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-10.14.0.tgz#dc4c9a9cbe64e44738fdad4fddea55b24cb8ef0a"
+  integrity sha512-Hlk3BZS8gnABTJM5JJODGiRiWkcpDk4Y6txab83JKY5ygvmOZlDeG4I8yJQe2gKHnZ1AVuIFhqNLGJOcbuAs8Q==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/center@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-10.9.0.tgz#da49b48b07c26f03d1ff8a9371821215cec442a3"
-  integrity sha512-xrvs9e3RausumKK9+OHPRhjr/vqvakSxrnjp/cNdU/rG/tGRaKFQ5JXN7yZWi0WWL2Hw5n++YUrLPrRP4cWVUA==
+"@dhis2-ui/center@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-10.14.0.tgz#c64f8b0133da181092c85b5146fd59f4416669ce"
+  integrity sha512-7y5R+Y17dDhKTU/XJ3QH7YlQ2Dx11mExAUAkX3oaziX5SFOg+S7WVyzr0w8tl3Q4K47G4aiz/VBPOvGTDzB+tQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/checkbox@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-10.9.0.tgz#2d7bf421aa6da25cd6beaebd9377f63cdd8ea083"
-  integrity sha512-0wA3XGhKh+3D4CQ83+BiQxK5vOYB/8PUYhyj4g00F+RF5JVkRnl8zLcVPV+KZTo5ONhyHIchNZZH4WrSSTk4WA==
+"@dhis2-ui/checkbox@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-10.14.0.tgz#e58c0f862ecc054ff7796fe0d6639d6ed12a1394"
+  integrity sha512-8e+eotFh1yc4U4dBBePXhWRDZ+A37VNuP213hBS49pap4vPcKIxLPSjtui7R1uCnWK9pcCDIUhXaCbc4lsVvnQ==
   dependencies:
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/required" "10.9.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/required" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/chip@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-10.9.0.tgz#6609971f5567f3c3a16d7193e21c0ab65266a39b"
-  integrity sha512-0Y06GyrEjq5ye+2lNd2EVI1k0Felze19XzsFrM8ilkrHhPzxD51QYZa+9NDFNtz/eIKncNf9a5v9WpTBG3wzUQ==
+"@dhis2-ui/chip@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-10.14.0.tgz#a186b33a7cb3ca6c1701d4906eb372253c8a7dab"
+  integrity sha512-sYHV9KUWCSDmBZj0G2MFxVCma1bF8qK8gOoXDZwlwsEWt6VqN0tlufC0uuYSv9Tb1PDYLELu1f1u4n1maSQn6g==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/cover@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-10.9.0.tgz#5c7387147991daf58b90435ed7ac30e6d94e5781"
-  integrity sha512-eCx2/b/2AbYOpF0MOPu3aVsllrAINQmaN6CidcI96gG8GCMoQ+cLgb/fqfwvYuD8PwG8sX9579ZLM+L5V0m27g==
+"@dhis2-ui/cover@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-10.14.0.tgz#baeffc510476d4b71ff8da587f9f95ca959213bb"
+  integrity sha512-3Ig74+8NEj2YIZ228Ixwu+aYYadIZ1E2n8yJhIKYVnAW8Ja5jo1GNnYaidvU3Ni6qIH/egiOiTDvPjaTYZRYvw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/css@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-10.9.0.tgz#a00a1c3c2decdab9f4f8328d72e69ebf303e919f"
-  integrity sha512-aUZsV4N7zQ05e20+ucZRZrMDdQmnSxehQrLFoxVFQncYmFkahtZY3bnuijbkD5/cYw8YdRjFr7xAgzPjgSFWGg==
+"@dhis2-ui/css@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-10.14.0.tgz#398ceb4d6ac850cc29cd0ef746104b33e33fc9ea"
+  integrity sha512-qTg86LK+BiZTyWMhuImNtHehj/lAevNixomNWW1T82cj1tLMBwRsH/E32WLzrBkYcFXQl7vyNyFPG1KfYLEwcg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/divider@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-10.9.0.tgz#7916affa4a054cc1648dfa6d0bff334a3a81cfb1"
-  integrity sha512-9ZZHqYJMsf19iXj7Jnmvaw0DZs6fZsBu+uOFuwI+U9fvEwPiCUPCJ9//78raLBnxN9DqCwJNtub1WhbmPYsPyQ==
+"@dhis2-ui/divider@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-10.14.0.tgz#2bf356dd82624ed7c33b941650c3694a016f4c16"
+  integrity sha512-1PFCuYzyxpZ9iQJ3bg0FlKsN9f0gLENep+NCO8R5g7qZfDAkmhLkhM6zrDQ4H/74cwrZ5jVfFTzevv4sG0YCEA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/field@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-10.9.0.tgz#94d6a0a1aa17373f5dfda903a8932cfa3c2af72e"
-  integrity sha512-wp8zaJziRhg94AJl9ZGp1PBCvz0nnpSclg3MKNn6pEOhUEHaSUeleMQ87KsnGvKrwa+0TkHtLgEOxfjtvj3aYA==
+"@dhis2-ui/field@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-10.14.0.tgz#a267c5012c32a07ff0d1f96d5f904dd22bd5aa5d"
+  integrity sha512-aOjg/Md9xrGnxhdJH3SD9uuXfASuYPKpkF9KC3K6jwxyji4HjMpClb6FkAKs9nw466x2LQ1DZ3xPf+XpPsDB0A==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/help" "10.9.0"
-    "@dhis2-ui/label" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/help" "10.14.0"
+    "@dhis2-ui/label" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/file-input@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-10.9.0.tgz#e5d5a7b3c582e2534f2f7060741485678a16c6ec"
-  integrity sha512-++5O2EYU6iGL9Zdhw+qWrDPJ4Qlmr/KrzhxlGhD/TbQPffVUBrxSl9czk5FLpg18mXeZWTtM/QWADYThIhHQkQ==
+"@dhis2-ui/file-input@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-10.14.0.tgz#bed43d44d7164c6c16e2f635607a0f474af17cb2"
+  integrity sha512-85Vqse39QeYUYDjHE+DhfoDmefX8ibg74IrJlWdW+MgKp5RQ6NyjYqePn0N4XnsJysiK2uXdp0wQy6QLCbvA2Q==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/label" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/status-icon" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/label" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/status-icon" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/header-bar@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-10.9.0.tgz#4e7eef065774435111c9e96d530be232cb3342f5"
-  integrity sha512-rQDxKv3VojhRfiYlIyvlZULC441i2cBmi++h25rKPukx76QRQdIeQRQ8/B2aZ8PQcWnc6jmdpioqYI2aJJKa7g==
+"@dhis2-ui/header-bar@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-10.14.0.tgz#1a3eb45f3b2e53b702891b6b137c8b82e5231f73"
+  integrity sha512-B70/BWmRAf/l/OTau0TFQS3ik9WhR3ygQvhxxvqN3Tsu3wxBx+BNQeiHGsrRRGxgIYu6kiWtn+gBsK9TyG96XA==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/center" "10.9.0"
-    "@dhis2-ui/divider" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/logo" "10.9.0"
-    "@dhis2-ui/menu" "10.9.0"
-    "@dhis2-ui/modal" "10.9.0"
-    "@dhis2-ui/user-avatar" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/center" "10.14.0"
+    "@dhis2-ui/divider" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/logo" "10.14.0"
+    "@dhis2-ui/menu" "10.14.0"
+    "@dhis2-ui/modal" "10.14.0"
+    "@dhis2-ui/user-avatar" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     moment "^2.29.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/help@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-10.9.0.tgz#98dab432b335aa14b5740fcdde0ebc3ddff08d60"
-  integrity sha512-hDpcmqoiK+K2eB8g2bTeSfq6LVDYt1MFU4jRAdSd8ZBvQeZctYOhReVfy8qyGSXIeTtZzBlHIdozo8IoURe/jQ==
+"@dhis2-ui/help@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-10.14.0.tgz#f642c892fcaac8f52da75812dc06bd592c06a3a1"
+  integrity sha512-kq9FWvLrrgxzvBD+gY6l5OepDqVZg/TxNGfzqr78DL22zCBJ295Io/xnCAdWFkCF07E/EnopfcEi7alM04SC2g==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/input@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-10.9.0.tgz#88e2fa55a53ab8ca07ced6daeaca365f30c4ab8b"
-  integrity sha512-SmZ1PUI+33F7d6UJ/CpOKDvjOz2okQZ2AW+XnE3JXWUVP1PRlnH6B0L+T9oefFiUOYPYQ9JRPlxsFdWkwap3Kw==
+"@dhis2-ui/input@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-10.14.0.tgz#57a3f2e302122fdf314aa7238c0119320e96f87a"
+  integrity sha512-Dlj4iYKcqp8fsSyxvZFo/25oq+T+RT2seGZ94QN+lnO0j66LNSSwdo1JJvvumP9T6VQA9tw7l1lTE7dqPJm5WQ==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/status-icon" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/status-icon" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/intersection-detector@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-10.9.0.tgz#40cdee6fa7319b7158ffdb6cb47a987d504af251"
-  integrity sha512-/bukE58dhJ11RI65WUKwbVuS1AHG4Xx2rnFlMwogM0WbOeuCCTT1ZIop80a00EdZ45TlmCiwS7L/lROdpmOFrw==
+"@dhis2-ui/intersection-detector@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-10.14.0.tgz#3996d7e88097ec7c57abe90324931965db6caf6f"
+  integrity sha512-oTRM52IOFYI+v8T1T6yj5XCk3ZZk4t8OUWA4yy4P0JGaxbTdL+0KbLpaK3k5ob1sKe7aEuIelUQ1jmkVgHDM8Q==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/label@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-10.9.0.tgz#2fb2e5af38a73d3dee19d169193ec7eccd8215f8"
-  integrity sha512-vFwy5eMx2iVx3pAjU1Z4WKdkVqjUEBucEkpjrM8ZjOGP2Jsd3hjsGGwrJlGwLCa8lc8S8ZPeyu/iOxgUcsj+cw==
+"@dhis2-ui/label@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-10.14.0.tgz#805cf9319f03f50906b5c0ace99aa969c898f5f0"
+  integrity sha512-2/DtqMurofkd5CK3tQ1UmaJHy0RxAAYBXxFjhjEESEA9wk2PrzjegqnMWjpFkvpXRQ3/0Ma8Gr/1iJyeCbj7ow==
   dependencies:
-    "@dhis2-ui/required" "10.9.0"
+    "@dhis2-ui/required" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/layer@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-10.9.0.tgz#867a4f2ae08f139f1784c391ea103d99d1416958"
-  integrity sha512-e5mTjftwT9mo2+I9SArwHPX5yzu7cM6KKuFFeVfunflRHV4bwJRzfSkxUIwSXIwfcJuRSHDSwr5OVUCvVdR9Rg==
+"@dhis2-ui/layer@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-10.14.0.tgz#d6d9c5f7661a4bd401c424a0c9d062abc1dc99c9"
+  integrity sha512-bj1A3dhIT9dTSj+vckaMRLbZXfRFrWFBRhASLI/fPYL16THVCssxyv29poUCOfSuTKneaMjDN8vt5t8T8PaPjQ==
   dependencies:
-    "@dhis2-ui/portal" "10.9.0"
+    "@dhis2-ui/portal" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/legend@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-10.9.0.tgz#8c05d748d0eaa6f837e7013fc6244afbab102317"
-  integrity sha512-bTOvXyQI6h6qmlBAZKSlGzrJrelxd8uuMd4sWQZ3sBwd1vy+B6QeOgbg4h3BEoXUdyhxbH3NlXQY91ub5zBwZQ==
+"@dhis2-ui/legend@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-10.14.0.tgz#8ceab91db4e1ea3250c1a267091f834993f0063a"
+  integrity sha512-Yhz2+QTwUmwmzcfRT4t3rzRrn4rAh0RzWMR05wnE8L2Cx7XBh3UdXd2DNv96BGaD5n9w2p1JkS+i975Rt6g9tg==
   dependencies:
-    "@dhis2-ui/required" "10.9.0"
+    "@dhis2-ui/required" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/loader@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-10.9.0.tgz#e4de71d9d0889774c614ae7e845b6e7c1d0b7b8a"
-  integrity sha512-Oj9niq3ad4vBvR76De3FmRAxzWe10ViAQmXVOvsfC9AtCMT2XwBIEhjzgE8LHm19GIyPbUvhjBP77okct5/DJA==
+"@dhis2-ui/loader@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-10.14.0.tgz#2257c95a9c35ded065200ed4bf114990b8d00965"
+  integrity sha512-0tUtTos7kF7LH0I4wzHC/1YuypSPx4Whibbk/oNaWCevEbzC7uaZ+aNNWiILSXmyiW8RCiKJqbdHHWKTgBIXLQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/logo@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-10.9.0.tgz#8169f6a3f29628c333bd722bcaf0df6c7f6e05bc"
-  integrity sha512-8BYsQHLFmhIzhLCWK4A6ctPIBkCYbmnI+NAKMgAmhTlcGdy02INOExvvooVT8zDmELpuo5Bt8PupBK3SRw4UNg==
+"@dhis2-ui/logo@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-10.14.0.tgz#90161059d2a9706164262427ca7f918fa16fa2de"
+  integrity sha512-hLPyDrSRKOHFB6VzJovXhSyuXfyYSkMWg4oudw4kbmqKS1I9pb+YjY6l0K0fb9JOU2TktQa0NJhA0REyiA1zZQ==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/menu@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-10.9.0.tgz#391ce65f6bffbeff5cf7cd4aaf85df6acfb50fc3"
-  integrity sha512-s1vLCm+7SnXQN85cZSwyptM8Dpj8gTkDc6aHcMmxwzgy2DypgusN5leS96dl2K3U7SMxkcsCAvObtx1JGdgXJw==
+"@dhis2-ui/menu@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-10.14.0.tgz#7c2a34f418543ec0db181413fdbb7b9c5cf5928f"
+  integrity sha512-K0fiSDs2Iagp1rJZTfJs8F8vEToaj8WZzlSTT4cpy0dZeSPz/tQHAqqm2i1nppBn66KhlUwyA/alJzwqeVkcUQ==
   dependencies:
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/divider" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2-ui/portal" "10.9.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/divider" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2-ui/portal" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/modal@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-10.9.0.tgz#cdcb8df537080e2bf1105fe44e3776fceec05a94"
-  integrity sha512-yBsP3hx2XT7QjDv2dzyGRFcppXyrkXvrzIhkylN4zZE7Z6WLodS2uVjp33MvEk8JsxQFgmQ0cYCsnQ63vL2++A==
+"@dhis2-ui/modal@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-10.14.0.tgz#9c92478633b011fe420158ccb44128f1a6b903aa"
+  integrity sha512-3ab1ZC9VMsnDVvfrWYW3mZIGugSvA2QZ7+KUZXrb7MQKoTu4dgUEWMAW92yv6fjRcqSog0ha4eqxwt1uDqL6GA==
   dependencies:
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/center" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/portal" "10.9.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/center" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/portal" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/node@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-10.9.0.tgz#3a1411d95d6b10ebeae6f481e05de534f6dc5e0a"
-  integrity sha512-eJjs+iaUei5Do9QKljYXtNkTW1StSRljUF+EknPT1u/nidgxoJUErG8nALUGp+NqBPbJR3+rfxRBEDeut3Qw+A==
+"@dhis2-ui/node@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-10.14.0.tgz#0d227be9045cca1afdc324c6c1c8f6ce72c2f0df"
+  integrity sha512-+3/FCUsLyDptcEw0UE0icS0+/6WKupbw4ncHI/lv4yHrQHBm6AlPJJSo0ap74wo/O6FGdCaZwaVMZTUSU/tteg==
   dependencies:
-    "@dhis2-ui/loader" "10.9.0"
+    "@dhis2-ui/loader" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/notice-box@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-10.9.0.tgz#5913c8c0d9a47546ea8308abd37285d8fde6198f"
-  integrity sha512-sWBCnVcR3CA+HYSYraJHI2+7S+wdoVO6YMh1JMvaZhaaDbMedkrdcahwuLgrHNYgYWwst/JQI9xSCWRksGxa+w==
+"@dhis2-ui/notice-box@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-10.14.0.tgz#c900867743e54a5e658ec3e353d7cd6f1809d112"
+  integrity sha512-ck4XQd9/tsQgnSJlNhvYe04d532uKqTjwDoFrN2HDhBGC84nOLVGDknFyUsZHR7xjwzsA8qgBcTGzyBXeE2V7A==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/organisation-unit-tree@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-10.9.0.tgz#7d0fafe78dbd68e91eee879e0e940aed31d83885"
-  integrity sha512-9xB+cro2KdV8YXehjkJEma6cz0CHbTY3WqwCx13V75NRWrf8MxIPoeekWbHSdyec83VH5X3O/Ms4cIECsPuUSA==
+"@dhis2-ui/organisation-unit-tree@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-10.14.0.tgz#ba7cd108608c2cf055cb197a5830fcc12b4d9161"
+  integrity sha512-1BSQTdDMFH9Ic14gR3ITUtqxB56ybVumE+5G1DSQJahJQhjZs01C0B5S7CBXo9I9NjkKgmVd0A3R8xgH132hbQ==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/checkbox" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/node" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/checkbox" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/node" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/pagination@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-10.9.0.tgz#cda840bf1792fa1b907f5391f5bc687f591b773f"
-  integrity sha512-k8K9HEP96/1zH8Q3mTUzMhxN9uQPH2Fd0sZ+TYOJi1UxYo2RnM1wKF4wDzZBbu/qORAGZOdCXW54ygmIhOyhcQ==
+"@dhis2-ui/pagination@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-10.14.0.tgz#1a9bde1db232bdd7be36dc80c533dee828db4912"
+  integrity sha512-fag7LRMIJ9anisiMCAoeXzYEXcAzr9jOzg8UqAmJvSLeALIXAylMp7f0Z7ycZj5MBd/UEHUrbUVjQ8g8ZyZyOA==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/select" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/select" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popover@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-10.9.0.tgz#c51d07d0fc3f660a3b67fa85aa6546fa6a8eb96d"
-  integrity sha512-S/KzaWO/7wReg6jywkg3bz2lSPuORH44Jami8GEWt22mmfkc4DMbKnOAlVvhfTkzc4ugRfIvgENn1ECmcmqfQA==
+"@dhis2-ui/popover@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-10.14.0.tgz#3093e28320f2ddf1f022bd3544cd3b0e0596f617"
+  integrity sha512-XlPOvzFTMWnbccG5GfOcVK33rnaLYYmr2TsBL1y414KDy/ufzlT1+rJ+wIElHE2OSLFN1eeXepAGx0RTUIvk0g==
   dependencies:
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popper@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-10.9.0.tgz#442cb87034f19e9cd572333864877c2d2b6b6dcc"
-  integrity sha512-d3tGBCxTq0nvcE3VnfpuNztzQlcfL7tDYyYK6HnQrlLcg0y5rybVrqYwkTd1KhLMMZNvkpkTMWR7Z/Lw1+4ipg==
+"@dhis2-ui/popper@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-10.14.0.tgz#0d7dcd9e5dfa0ecd4bba6479c70d6c9bd735387c"
+  integrity sha512-tN3gVtITEKX9dcdQJYLpzSaBUmzkc7K4LDHIprwFbmBVolOsDapO6qr2fnCcUmQRw0FQUUnYKKrwvEw8zw/XFA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     "@popperjs/core" "^2.11.8"
     classnames "^2.3.1"
     prop-types "^15.7.2"
     react-popper "^2.3.0"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2-ui/portal@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-10.9.0.tgz#d7ea08f734b7fc4e5dd299f847729b894eb6976a"
-  integrity sha512-D7/UETkWBjubaFkZKQRLdlgjFRHnqvzyV25eNlNLLQuoIqHU4MoaU7Og8QLMzJxO0Sm6rdaChT5k/GDEm0GoWA==
+"@dhis2-ui/portal@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-10.14.0.tgz#dbd4e7eca10c6f0443d6bf4541becea832858705"
+  integrity sha512-+gYKomRJtJIbHaz21RcUJjOTNUA7Gasmfweaw41UqOmHuUNpTbMcqdcB3D0b8tnsCDoXqapZHncYA4zMhks6jg==
   dependencies:
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/radio@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-10.9.0.tgz#6af6742e9ff0dbe435d65eda554e00f3380a16d8"
-  integrity sha512-HczqwQxMVzE99pmHbmlWDdQ36xvwbpYnQreH0qLB6y/+8qqZEmPwWGl7uaCZLId/bBDXrthII2mqE7VfBGxGPA==
+"@dhis2-ui/radio@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-10.14.0.tgz#5702cf78a4e5f6a2230eb412ef1d5b5af55360a0"
+  integrity sha512-TdbzrvMzA7xWIbjQUNTaLkEL3fsrs14uYXJ+99jaY5v3DRgkKJina61oRtwFd7PW8nbXBeRy/8vmfOnB1pJsew==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/required@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-10.9.0.tgz#223a59854b66c59a4d2f7f1b3ac11315ed5740f1"
-  integrity sha512-p/yNE+j6HEJFUZCspjf8P3e4n12lVJu7t1UQZV9z88742bY1gLMz59RmKLCG1+sGuKYe+9neJs98zkvas3AMNQ==
+"@dhis2-ui/required@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-10.14.0.tgz#1d0a7493d9f25a13a7401e25ac9261b3329c045c"
+  integrity sha512-3I2Y51bLNV/iZa6YXXGHcVHz9TB6qmIASA6sKcZrwfBkjYgJVmKEP4xuA/0JYhYWHbSkLVluiutBB4eLPhMbCA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/segmented-control@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-10.9.0.tgz#6f06512b03232a7c95a1d365fdccbb395148ffc9"
-  integrity sha512-wDPxXvXV+kjrjpI0WpTYX48x5+3PQyHrAFQ/TYC/Hisiy0uuKKQPcG0GH47oV3HFn31gQZxjGaX1OC62N95kxg==
+"@dhis2-ui/segmented-control@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-10.14.0.tgz#b07626efb28a5371b69bc79e6d78924ed5f73476"
+  integrity sha512-t5U1t7yMQ9eF7USMW2SQtNg2xGFsVKFlQ/NTCTUiEgpQW+AAvmX+2Ib/pz6E3lwFfydyE1HCalNWamRTQg2bGw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/select@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-10.9.0.tgz#9345a26c3c38ce0c8e0ddba965ac0cb4bac061eb"
-  integrity sha512-fVTSGRLfeJQKhP1tmmxyl+XF8QOaoE18JssoRQ/3zdMXiKCLWwjKAMdvDh+TdqZxGzokUhg/dPJhlhwoFo4nkg==
+"@dhis2-ui/select@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-10.14.0.tgz#d93687550a5c1fbbf309c4b173e7be0d3cc4e7b1"
+  integrity sha512-ze1B/Gw8gKf+z/44z9g39w2NcQvu70scTHJWnzFVw9HSn+xiBZPbqK64vZ+RBt84NijP/t3B3/H5218MPR+LnA==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/checkbox" "10.9.0"
-    "@dhis2-ui/chip" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2-ui/status-icon" "10.9.0"
-    "@dhis2-ui/tooltip" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/checkbox" "10.14.0"
+    "@dhis2-ui/chip" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2-ui/status-icon" "10.14.0"
+    "@dhis2-ui/tooltip" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/selector-bar@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-10.9.0.tgz#32328f04e5be6a2d858ffcfd7bda430ec02b952e"
-  integrity sha512-jqeQnB5iPYNUM0SL7iEi5rOQh+rkkszxuLJy/QOqpWAdsRAUftFsNldKoewV8ycYyagNiV6sIRqRp4oVv93abw==
+"@dhis2-ui/selector-bar@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-10.14.0.tgz#8a160348f873726c16c520e7b4e9f6f248fa73b7"
+  integrity sha512-n0O28/uGzukbsMHTp85ijkuNEOFGL5jlxlWCzWLW2Tf5kvPzff8nJJ86JX3aBaR9k1QgZZZv95vuanmN2K/0hg==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/sharing-dialog@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-10.9.0.tgz#e56cf25ad621c4b97ba1d41ce6b564ff5d442e60"
-  integrity sha512-CZhIHY3ZIJXX3sTB2zaPaFGaLmRD0/Fc5qHOVvxAHWAshpxr/xhxjG5kmQjGHRuiWbdmGefARWJPRAYCyC6s4A==
+"@dhis2-ui/sharing-dialog@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-10.14.0.tgz#afecab4c7426badbf780b78770140f1cbf12ed44"
+  integrity sha512-t2GSIjaWjy/sDo0w970wpdQSRaocNy5YLFPNWOKgFuAPWWwRG4sUOpQFNSTJ08Com3pL/Iih4/D1h8MIe/VmIA==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/divider" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/menu" "10.9.0"
-    "@dhis2-ui/modal" "10.9.0"
-    "@dhis2-ui/notice-box" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2-ui/select" "10.9.0"
-    "@dhis2-ui/tab" "10.9.0"
-    "@dhis2-ui/tooltip" "10.9.0"
-    "@dhis2-ui/user-avatar" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/divider" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/menu" "10.14.0"
+    "@dhis2-ui/modal" "10.14.0"
+    "@dhis2-ui/notice-box" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2-ui/select" "10.14.0"
+    "@dhis2-ui/tab" "10.14.0"
+    "@dhis2-ui/tooltip" "10.14.0"
+    "@dhis2-ui/user-avatar" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     "@react-hook/size" "^2.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/status-icon@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-10.9.0.tgz#58d8e26f887dc600aa57515d24d830cefe9b235d"
-  integrity sha512-vnN5arJnPxgbL1kzIn2xufRTpSiQ06YK94YDj1zlmFmKdWv3Z26vR9HYTGUcxmIxpfVfPqGsawdsC0VWrHo/Yw==
+"@dhis2-ui/status-icon@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-10.14.0.tgz#add1b9653606c9f8220ba0dbe65be5f0a850f86b"
+  integrity sha512-X0fsoW3PtsyBc0aWm2yCX3iNH1JFSfxO4l5L9/ttJ1F/AJmoXUsKfR77IbktP+IbnMXVxVocr+ePBXbbalOnvA==
   dependencies:
-    "@dhis2-ui/loader" "10.9.0"
+    "@dhis2-ui/loader" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/switch@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-10.9.0.tgz#d6c21be1cc928b97a2042614e277524322e7ce1f"
-  integrity sha512-7PoJzdkti3dkIEJojPx5pM7wisEN3mk4oJFXsrL8tmm6BzKd3icIkJpKHEhIy5QJGAs85LUvouOPLskST7sPfA==
+"@dhis2-ui/switch@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-10.14.0.tgz#6f60de1c5ef5f08a313d5b06125bfcb379d97fa6"
+  integrity sha512-wxATS/jO553l8F4V+9TBlg1Q84diT1KoWL6NRYRKCUxQAEB1o29sglqk8H0CwV0c3+s5WZHHAVF/gya8YCmjIA==
   dependencies:
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/required" "10.9.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/required" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tab@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-10.9.0.tgz#ea2b65a7147881adddefa445934281b96eb8252e"
-  integrity sha512-k4ktVGVSAjziAn2IvSIk6ZsXB9Ve0ZSxZCYTefmIFA5GWhHw2Cur6z2b0M3Bq1Ck9WAJgopkoXVRt5XuD2XV2w==
+"@dhis2-ui/tab@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-10.14.0.tgz#472e5456648d8ed69da52d4225ad7df8dbbd190e"
+  integrity sha512-QvxS8I8hrdamD9Gh0qMCXSThgl1ix8sYfHR7bAFoLbwfn8gw6SlFCUc4QeIB/swnI0hgYl8dc41ind1JnxOvjw==
   dependencies:
-    "@dhis2-ui/tooltip" "10.9.0"
+    "@dhis2-ui/tooltip" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/table@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-10.9.0.tgz#5a5af77c0904521a4f288638590d3f4256ddfb58"
-  integrity sha512-YGireKjLQg9re2lw3i3VX0f0dAgNS0c01NgrOO4XmAcJGrvItH1TQvCaPTQxFkkutCXGn0tVXVv0K/0RN3gcyQ==
+"@dhis2-ui/table@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-10.14.0.tgz#6595f823baff22892087b98bae59fe9e3054bd39"
+  integrity sha512-QM1i83bBpdRus2mF0QcpTC9eMJNTbBqpwxYlHsKWnUGR8ldKsF8/W5slaM1E7fKdQ29JugXkzlgZDIr5vhKHyA==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tag@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-10.9.0.tgz#a0e6b9928b813c9fe3407b4fb1bf07910de767f8"
-  integrity sha512-udCNGy86PkkQxrumfB99/iXEyqTXwm/Rfzjsa1JrGAl6Sr5FpTT8t4lptXqC/sbTeOQMgzfY1UHp8TAU7dJYlA==
+"@dhis2-ui/tag@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-10.14.0.tgz#3e51e68a1dfdbaee4b6ee1c03ceb90a301759cb2"
+  integrity sha512-U3vX1wk6amBvSmepdvxfW3d6neVaZvJ26AkcvGWBuNVG85SrZjBrqJBsVN6bDmdXZbDDW3RJ7Qtcj4MKD9sBmw==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/text-area@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-10.9.0.tgz#335e9cccf508b52106d306063451da88eef738e6"
-  integrity sha512-hhTqeGrSUBaakiAKtSy+XLik7AWqL1vk+xZ92Un3egTwzKtwONSg5WiOzW4xKQ4YSlhaUAFD3UfX5Z7zyKE7gA==
+"@dhis2-ui/text-area@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-10.14.0.tgz#8dd0eb80b54d5eed30efb9df9dc46598a32da136"
+  integrity sha512-F/g8cP+6ifdCyyzCGcg2Yq9qrAgsudHO/XINHE1RtZaUwj9HBOTWoPtln8S9ZKWmv+eOJPKYNzkyfL526hR5Og==
   dependencies:
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/status-icon" "10.9.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/status-icon" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tooltip@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-10.9.0.tgz#de6738b1a3b9b5f3984ac86111b1fae15bc02d0c"
-  integrity sha512-sOva6jdWXVmMaZT74f8cjjrgCUNZ5AaHGngyM7II1JP4uQCaDqmZNLuR7iX2Qp1cL/fUwS83PuK/Sn3fQV/KrQ==
+"@dhis2-ui/tooltip@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-10.14.0.tgz#797d627b33aebb39861ca000c96406775cf29f08"
+  integrity sha512-hqpIIhyeqrbsEsvTmjj7HDay238t6w0wtoOAPiGg2K87is2U4+yy3pXGizDBFAGzkUkGqLr9ihdBC99JPVbCiw==
   dependencies:
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2-ui/portal" "10.9.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2-ui/portal" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/transfer@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-10.9.0.tgz#59d1bd24e86d1bc4ea39dfb8679237ea8f55099f"
-  integrity sha512-F2hU7WBD/I/2MF48WfxCfeX1zwRmnIzgl1IikAuyS8zvh8j6MlC4i98b0+S4Os25NqcmXEmT4u/FkWB6nU6Zow==
+"@dhis2-ui/transfer@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-10.14.0.tgz#7a6abb8f4d6e88bef636bfcc8c1d18a0146bd3e1"
+  integrity sha512-RSxQ7YV6Mr3A/QEitVYCnUxEmmf/82Jto6tfTopV9pHO4pBFpRIiKPVyvUGrgRzPLNxUJrR04qMTlARr0mUP0g==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/intersection-detector" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/intersection-detector" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/tooltip" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/user-avatar@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-10.9.0.tgz#1cd3f1ace2fdb5afb76d34d59efd435eb50fd8c4"
-  integrity sha512-LI8L+ULxqoBV8JG95a2VVeYGjgl/roe8G6xDVzwTgLOwrxnvvyM4RBdfxRDdMnuceq2CwiPEJ9OndtOAj8v/OQ==
+"@dhis2-ui/user-avatar@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-10.14.0.tgz#708807b2e574ec3cda6e0be7ba28637d09d11a7a"
+  integrity sha512-ViXgLjLM42FPHzSvDDBaG6Mcuhb4e5O6a2A5NOg1IDSZHFWLsS+y4Z62lgUv0keliVa/0vZao0ifcNtUWDofwg==
   dependencies:
     "@dhis2/prop-types" "^3.1.2"
-    "@dhis2/ui-constants" "10.9.0"
+    "@dhis2/ui-constants" "10.14.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
@@ -2276,91 +2282,91 @@
     workbox-routing "^7.1.0"
     workbox-strategies "^7.1.0"
 
-"@dhis2/ui-constants@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-10.9.0.tgz#a524da18617f5115106500c85e7b995a9d2a4323"
-  integrity sha512-Btlc1DmUiojRvA+rkl9QQIpmsBRLAYqiWYwqna5yQYQfiHsZcmw91KCbgyDhNF29tX2Q/iLylClDAngLDwFa5A==
+"@dhis2/ui-constants@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-10.14.0.tgz#09ee584fe25414210d789978316de074ac790b71"
+  integrity sha512-HmHKsYZ9eelHQZsv9g75iP9YNWpMpWP6+fBBBPE1EBNUHWItQYQsqZf5zX9zZGTDeX6REQEAEZVRrD4r2De/2Q==
   dependencies:
     prop-types "^15.7.2"
 
-"@dhis2/ui-forms@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-10.9.0.tgz#877a1a9d04d31082b1c581e84d1088bad34df287"
-  integrity sha512-b7IViD49+OD3VG9jHq9DlreQq5a6vQHSACnAozVhNEDHj1HNLt6PN/BN543umSEhC5dCYsZ30T4zsKc5zuOR8Q==
+"@dhis2/ui-forms@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-10.14.0.tgz#b59d383589d447d8cb61ae29c8c6abcd61980147"
+  integrity sha512-liZSvlkIOITK0YWf6ZQ20B0gnulQrDYA4QPHY0xIp3su3bTgcvO4EL4P2MOWxxQpqJunWOy5MIrwhW3A/csM3Q==
   dependencies:
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/checkbox" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/file-input" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/radio" "10.9.0"
-    "@dhis2-ui/select" "10.9.0"
-    "@dhis2-ui/switch" "10.9.0"
-    "@dhis2-ui/text-area" "10.9.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/checkbox" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/file-input" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/radio" "10.14.0"
+    "@dhis2-ui/select" "10.14.0"
+    "@dhis2-ui/switch" "10.14.0"
+    "@dhis2-ui/text-area" "10.14.0"
     "@dhis2/prop-types" "^3.1.2"
     classnames "^2.3.1"
     final-form "^4.20.2"
     prop-types "^15.7.2"
     react-final-form "^6.5.3"
 
-"@dhis2/ui-icons@10.9.0":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-10.9.0.tgz#3c3a35441ff068235942bfc969661f5d9844c534"
-  integrity sha512-tLrC4T2jPOgRqBZadsHIFgyCI7xEmmU1AkcU3fMp6B1WHh/wcnq/GXUuvYDWuYQSNqXlN4lpCfFk+qPjU+8/zw==
+"@dhis2/ui-icons@10.14.0":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-10.14.0.tgz#4f8f3e5db0854f3bec86a11aa4ec9d16596c2416"
+  integrity sha512-tWzOIMePpNU7+FgZFyp+ilutabc0JHHK4arPyLwUkTbFODLUOENFbqjN4Tjtooys/mZFF4ewWaFeIpgMMEskZA==
 
-"@dhis2/ui@^10.1.11", "@dhis2/ui@^10.7.8":
-  version "10.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-10.9.0.tgz#4de964f719bdb1742ffdeba0a931732b47d29d9e"
-  integrity sha512-9Rv9hEA/0t0764Bu28v1G00HoevTy7hPY2VyXkWcNNeTJrpdFe6K5eBrpwN/RuESxw0QkyWY2WqRhYCAcNicaw==
+"@dhis2/ui@^10.14.0", "@dhis2/ui@^10.7.8":
+  version "10.14.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-10.14.0.tgz#69a8182fb3f85fc7c5dc3f5d867b36e7e4b3e015"
+  integrity sha512-CfoLOCHs1KMjt9DQ7Hdi7vXmf4XMdAFdCOHS7AM/e8/2VPPILCrmNZslnLqJZkX7pbT/ZC8qm4XwLP8JE+4slA==
   dependencies:
-    "@dhis2-ui/alert" "10.9.0"
-    "@dhis2-ui/box" "10.9.0"
-    "@dhis2-ui/button" "10.9.0"
-    "@dhis2-ui/calendar" "10.9.0"
-    "@dhis2-ui/card" "10.9.0"
-    "@dhis2-ui/center" "10.9.0"
-    "@dhis2-ui/checkbox" "10.9.0"
-    "@dhis2-ui/chip" "10.9.0"
-    "@dhis2-ui/cover" "10.9.0"
-    "@dhis2-ui/css" "10.9.0"
-    "@dhis2-ui/divider" "10.9.0"
-    "@dhis2-ui/field" "10.9.0"
-    "@dhis2-ui/file-input" "10.9.0"
-    "@dhis2-ui/header-bar" "10.9.0"
-    "@dhis2-ui/help" "10.9.0"
-    "@dhis2-ui/input" "10.9.0"
-    "@dhis2-ui/intersection-detector" "10.9.0"
-    "@dhis2-ui/label" "10.9.0"
-    "@dhis2-ui/layer" "10.9.0"
-    "@dhis2-ui/legend" "10.9.0"
-    "@dhis2-ui/loader" "10.9.0"
-    "@dhis2-ui/logo" "10.9.0"
-    "@dhis2-ui/menu" "10.9.0"
-    "@dhis2-ui/modal" "10.9.0"
-    "@dhis2-ui/node" "10.9.0"
-    "@dhis2-ui/notice-box" "10.9.0"
-    "@dhis2-ui/organisation-unit-tree" "10.9.0"
-    "@dhis2-ui/pagination" "10.9.0"
-    "@dhis2-ui/popover" "10.9.0"
-    "@dhis2-ui/popper" "10.9.0"
-    "@dhis2-ui/portal" "10.9.0"
-    "@dhis2-ui/radio" "10.9.0"
-    "@dhis2-ui/required" "10.9.0"
-    "@dhis2-ui/segmented-control" "10.9.0"
-    "@dhis2-ui/select" "10.9.0"
-    "@dhis2-ui/selector-bar" "10.9.0"
-    "@dhis2-ui/sharing-dialog" "10.9.0"
-    "@dhis2-ui/switch" "10.9.0"
-    "@dhis2-ui/tab" "10.9.0"
-    "@dhis2-ui/table" "10.9.0"
-    "@dhis2-ui/tag" "10.9.0"
-    "@dhis2-ui/text-area" "10.9.0"
-    "@dhis2-ui/tooltip" "10.9.0"
-    "@dhis2-ui/transfer" "10.9.0"
-    "@dhis2-ui/user-avatar" "10.9.0"
-    "@dhis2/ui-constants" "10.9.0"
-    "@dhis2/ui-forms" "10.9.0"
-    "@dhis2/ui-icons" "10.9.0"
+    "@dhis2-ui/alert" "10.14.0"
+    "@dhis2-ui/box" "10.14.0"
+    "@dhis2-ui/button" "10.14.0"
+    "@dhis2-ui/calendar" "10.14.0"
+    "@dhis2-ui/card" "10.14.0"
+    "@dhis2-ui/center" "10.14.0"
+    "@dhis2-ui/checkbox" "10.14.0"
+    "@dhis2-ui/chip" "10.14.0"
+    "@dhis2-ui/cover" "10.14.0"
+    "@dhis2-ui/css" "10.14.0"
+    "@dhis2-ui/divider" "10.14.0"
+    "@dhis2-ui/field" "10.14.0"
+    "@dhis2-ui/file-input" "10.14.0"
+    "@dhis2-ui/header-bar" "10.14.0"
+    "@dhis2-ui/help" "10.14.0"
+    "@dhis2-ui/input" "10.14.0"
+    "@dhis2-ui/intersection-detector" "10.14.0"
+    "@dhis2-ui/label" "10.14.0"
+    "@dhis2-ui/layer" "10.14.0"
+    "@dhis2-ui/legend" "10.14.0"
+    "@dhis2-ui/loader" "10.14.0"
+    "@dhis2-ui/logo" "10.14.0"
+    "@dhis2-ui/menu" "10.14.0"
+    "@dhis2-ui/modal" "10.14.0"
+    "@dhis2-ui/node" "10.14.0"
+    "@dhis2-ui/notice-box" "10.14.0"
+    "@dhis2-ui/organisation-unit-tree" "10.14.0"
+    "@dhis2-ui/pagination" "10.14.0"
+    "@dhis2-ui/popover" "10.14.0"
+    "@dhis2-ui/popper" "10.14.0"
+    "@dhis2-ui/portal" "10.14.0"
+    "@dhis2-ui/radio" "10.14.0"
+    "@dhis2-ui/required" "10.14.0"
+    "@dhis2-ui/segmented-control" "10.14.0"
+    "@dhis2-ui/select" "10.14.0"
+    "@dhis2-ui/selector-bar" "10.14.0"
+    "@dhis2-ui/sharing-dialog" "10.14.0"
+    "@dhis2-ui/switch" "10.14.0"
+    "@dhis2-ui/tab" "10.14.0"
+    "@dhis2-ui/table" "10.14.0"
+    "@dhis2-ui/tag" "10.14.0"
+    "@dhis2-ui/text-area" "10.14.0"
+    "@dhis2-ui/tooltip" "10.14.0"
+    "@dhis2-ui/transfer" "10.14.0"
+    "@dhis2-ui/user-avatar" "10.14.0"
+    "@dhis2/ui-constants" "10.14.0"
+    "@dhis2/ui-forms" "10.14.0"
+    "@dhis2/ui-icons" "10.14.0"
     prop-types "^15.7.2"
 
 "@dual-bundle/import-meta-resolve@^4.1.0":
@@ -2909,9 +2915,9 @@
     tslib "^2.3.1"
 
 "@juggle/resize-observer@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
-  integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
 "@keyv/serialize@^1.0.2":
   version "1.0.2"
@@ -2980,15 +2986,13 @@
   integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
 
 "@react-hook/resize-observer@^1.2.1":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.5.tgz#b59e2300de98bc6ddc6946942f21243cde10f984"
-  integrity sha512-qa0pPvRxq5VbdI8mMK2apPFsZOckhQ6D3Jc9yLuyHMNhui8yEih4qyFCZBDzzK3ymZS6LAltVSVg3l1Dg9vA0w==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.6.tgz#9a8cf4c5abb09becd60d1d65f6bf10eec211e291"
+  integrity sha512-DlBXtLSW0DqYYTW3Ft1/GQFZlTdKY5VAFIC4+km6IK5NiPPDFchGbEJm1j6pSgMqPRHbUQgHJX7RaR76ic1LWA==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@react-hook/latest" "^1.0.2"
     "@react-hook/passive-layout-effect" "^1.2.0"
-    "@types/raf-schd" "^4.0.0"
-    raf-schd "^4.0.2"
 
 "@react-hook/size@^2.1.2":
   version "2.1.2"
@@ -3451,11 +3455,6 @@
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
   integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
-
-"@types/raf-schd@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/raf-schd/-/raf-schd-4.0.1.tgz#1f9e03736f277fe9c7b82102bf18570a6ee19f82"
-  integrity sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A==
 
 "@types/resolve@1.20.2":
   version "1.20.2"
@@ -6560,9 +6559,9 @@ filter-obj@^1.1.0:
   integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 final-form@^4.20.2:
-  version "4.20.2"
-  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.2.tgz#c820b37d7ebb73d71169480256a36c7e6e6c9155"
-  integrity sha512-5i0IxqwjjPG1nUNCjWhqPCvQJJ2R+QwTwaAnjPmFnLbyjIHWuBPU8u+Ps4G3TcX2Sjno+O5xCZJzYcMJEzzfCQ==
+  version "4.20.10"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.10.tgz#1a484be6e9a91989121c054dcbd6f48bad051ecc"
+  integrity sha512-TL48Pi1oNHeMOHrKv1bCJUrWZDcD3DIG6AGYVNOnyZPr7Bd/pStN0pL+lfzF5BNoj/FclaoiaLenk4XUIFVYng==
   dependencies:
     "@babel/runtime" "^7.10.0"
 
@@ -8489,9 +8488,9 @@ js2xmlparser@^4.0.2:
     xmlcreate "^2.0.4"
 
 jsbi@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
-  integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.2.tgz#8a4d05d4e09907d73042135b6aa55a6d161ee955"
+  integrity sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -9325,10 +9324,15 @@ mocha@^10.4.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-moment@^2.24.0, moment@^2.29.1:
+moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.0.0:
   version "2.0.0"
@@ -9504,7 +9508,7 @@ oauth-sign@~0.9.0:
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -10157,11 +10161,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-raf-schd@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
-  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
-
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10188,16 +10187,16 @@ react-dom@^18:
     scheduler "^0.23.2"
 
 react-fast-compare@^3.0.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-final-form@^6.5.3:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.3.tgz#b60955837fe9d777456ae9d9c48e3e2f21547d29"
-  integrity sha512-FCs6GC0AMWJl2p6YX7kM+a0AvuSLAZUgbVNtRBskOs4g984t/It0qGtx51O+9vgqnqk6JyoxmIzxKMq+7ch/vg==
+  version "6.5.9"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.9.tgz#644797d4c122801b37b58a76c87761547411190b"
+  integrity sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==
   dependencies:
-    "@babel/runtime" "^7.12.1"
+    "@babel/runtime" "^7.15.4"
 
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
@@ -11318,7 +11317,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11343,6 +11342,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11435,7 +11443,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11982,10 +11997,15 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
+tslib@^2.0.1, tslib@^2.0.3:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
+tslib@^2.3.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.1.0:
   version "2.1.0"
@@ -12850,8 +12870,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12873,6 +12892,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR updates the UI library (note we need to use a resolution because the UI library dependency in app-shell is not the same).

This picks up the change to stop invalid regular expressions crashing transfer filter (https://github.com/dhis2/ui/pull/1740)